### PR TITLE
build.gradle: Fix Gradle 9 deprecation warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,11 @@ allprojects {
 
     dependencies {
         testImplementation("org.bitcoinj:bitcoinj-core:0.17-alpha3");
+
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
         testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
         testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
     }
 


### PR DESCRIPTION
Manually declare test framework implementation dependencies

See:
https://docs.gradle.org/8.6/userguide/upgrading_version_8.html#test_framework_implementation_dependencies