### PR TITLE
GitHub Actions: Install Nix, run tests and examples

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,4 +33,6 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew build -x test  # Skip tests because they will fail without libsecp256k1 installed.
+        run: ./gradlew build
+      - name: Run Java (Schnorr) Example
+        run: ./gradlew secp256k1-examples-java:run


### PR DESCRIPTION
~~This is a child of PR #15.~~

* Install Nix with GitHub Actions
* Install `secp256k1` into the user profile
* Update the CI build to re-enable the running of tests, and also to run the Java (Schnorr) ~~and Kotlin (ECDSA)~~ examples.