### PR TITLE
secp256k1-bouncy module, mark Bouncy Castle as an API dependency

### DIFF
--- a/secp256k1-bouncy/build.gradle
+++ b/secp256k1-bouncy/build.gradle
@@ -10,7 +10,7 @@ ext.moduleName = 'org.bitcoinj.secp256k1.bouncy'
 
 dependencies {
     api project(':secp256k1-api')
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
+    api 'org.bouncycastle:bcprov-jdk18on:1.77'  // TODO: Make this a non-API dependency, see BouncyPrivKey
 }
 
 jar {

--- a/secp256k1-bouncy/src/main/java/org/bitcoinj/secp256k1/bouncy/BouncyPrivKey.java
+++ b/secp256k1-bouncy/src/main/java/org/bitcoinj/secp256k1/bouncy/BouncyPrivKey.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 /**
  *
  */
+// TODO: Remove API dependency on o.bouncycastle.m.e.c.s.SecP256K1FieldElement
 public class BouncyPrivKey extends SecP256K1FieldElement implements P256k1PrivKey {
 
     private boolean isDestroyed = false;

--- a/secp256k1-integration-test/build.gradle
+++ b/secp256k1-integration-test/build.gradle
@@ -13,8 +13,6 @@ dependencies {
     implementation project(':secp256k1-bouncy')
     implementation project(':secp256k1-foreign')
     implementation project(':secp256k1-sandbox')
-
-    //implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
 }
 
 jar {

--- a/secp256k1-sandbox/build.gradle
+++ b/secp256k1-sandbox/build.gradle
@@ -12,8 +12,6 @@ dependencies {
     api project(':secp256k1-api')
     api project(':secp256k1-bouncy')
     api project(':secp256k1-foreign')
-
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
 }
 
 jar {


### PR DESCRIPTION
`BouncyPrivKey` extends `SecP256K1FieldElement` and therefore has an API dependency on Bouncy Castle. We should remove this dependency, but for now we'll just mark this module as having an API dependency on Bouncy Castle.

Marking it as an API dependency allows us to remove declarations of direct dependencies on Bouncy Castle from modules using secp256k1-bouncy. When we remove the API dependency modules using secp256k1-bouncy will not have to change their Gradle/Maven dependency declarations.  (But if they actually depend on `SecP256K1FieldElement` that will have to change)

I plan on fixing this for 0.0.3 or maybe even sooner.