### PR TITLE
Kotlin examples: Use Bouncy256k1

### DIFF
--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
@@ -1,6 +1,6 @@
 package org.bitcoinj.secp256k1.kotlin.examples
 
-import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign
+import org.bitcoinj.secp256k1.bouncy.Bouncy256k1
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.*
@@ -20,7 +20,7 @@ object Ecdsa {
     @JvmStatic
     fun main(args: Array<String>) {
         println("Running secp256k1-jdk Ecdsa example...")
-        Secp256k1Foreign().use { secp ->
+        Bouncy256k1().use { secp ->
             /* === Key Generation === */
             /* Return a non-zero, in-range private key */
             val privKey = secp.ecPrivKeyCreate()

--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
@@ -1,7 +1,7 @@
 package org.bitcoinj.secp256k1.kotlin.examples
 
 import org.bitcoinj.secp256k1.api.P256K1XOnlyPubKey
-import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign
+import org.bitcoinj.secp256k1.bouncy.Bouncy256k1
 import java.util.*
 
 /**
@@ -16,7 +16,7 @@ object Schnorr {
     @JvmStatic
     fun main(args: Array<String>) {
         println("Running secp256k1-jdk Schnorr example...")
-        Secp256k1Foreign().use { secp ->
+        Bouncy256k1().use { secp ->
             /* === Key Generation === */
             /* Return a non-zero, in-range private key */
             val keyPair = secp.ecKeyPairCreate()


### PR DESCRIPTION
This is because Kotlin does not yet support JDK 22, so
we'll have to limit the Kotlin examples to the (incomplete) Bouncy
implementation for  now...

~~This is a child of PR #18, but is ready to merge once PR #18 is merged.~~ 
Update: Rebased