### PR TITLE
WIP: Graal native-image build of Java Schnorr Example

### DIFF
--- a/.github/workflows/graal.yml
+++ b/.github/workflows/graal.yml
@@ -1,0 +1,67 @@
+name: GraalVM Build
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  validate_gradle_wrapper:
+    name: "Validate Gradle Wrapper"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4
+
+  build_gradle:
+    needs: validate_gradle_wrapper
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-14]
+        java: [ '25-ea' ]
+        distribution: [ 'graalvm' ]
+      fail-fast: false
+    name: ${{ matrix.os }} ${{ matrix.java }} (via setup-graalvm)
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install secp256k1 with Nix
+        run: nix profile install nixpkgs#secp256k1
+      - name: Build (JIT) with Gradle
+        run: ./gradlew -PjavaToolchainVersion=25 build
+      - name: Run Java & Kotlin Examples
+        run: ./gradlew -PjavaToolchainVersion=25 build run runEcdsa
+      - name: Build Native Image with Gradle
+        run: ./gradlew -PjavaToolchainVersion=25 build secp-examples-java:nativeCompile
+      - name: Run Schnorr Native Example
+        run: |
+          export LD_LIBRARY_PATH="$HOME/.nix-profile/lib"
+          export DYLD_LIBRARY_PATH="$HOME/.nix-profile/lib"
+          ./secp-examples-java/build/schnorr-example
+
+  build_nix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-14]
+      fail-fast: false
+    name: ${{ matrix.os }} Nix
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install secp256k1 with Nix
+        run: nix profile install nixpkgs#secp256k1
+      - name: Build in Nix development shell
+        run: nix develop -c gradle build run runEcdsa

--- a/README.adoc
+++ b/README.adoc
@@ -100,6 +100,29 @@ Run the script:
 
 * `./secp-examples-java/build/install/secp-examples-java/bin/secp-examples-java`
 
+== Build and run a native image (Currently targets GraalVM for JDK 25-ea)
+
+To build using GraalVM `native-image`:
+
+. Make sure you have GraalVM 25 (EA 31) or later installed
+. Make sure `GRAALVM_HOME` points to the Graal JDK 25 installation
+. `./gradlew secp-examples-java:nativeCompileSchnorr`
+
+To run the compiled, native executable:
+
+On Linux set up `LD_LIBRARY_PATH`:
+
+. `export LD_LIBRARY_PATH="$HOME/.nix-profile/lib:$LD_LIBRARY_PATH"`
+
+On macOS set up `DYLD_LIBRARY_PATH`:
+
+. `export DYLD_LIBRARY_PATH="$HOME/.nix-profile/lib:$DYLD_LIBRARY_PATH"`
+
+Run the native image binary:
+
+. `./secp-examples-java/build/schnorr-example`
+. Don't blink!
+
 == Building with Nix
 
 NOTE:: We currently only support setting up a development environment with Nix. In the future we hope to support a full Nix build.

--- a/secp-examples-java/build.gradle
+++ b/secp-examples-java/build.gradle
@@ -9,12 +9,16 @@ dependencies {
     implementation project(':secp-api')
     runtimeOnly project(':secp-bouncy')
     runtimeOnly project(':secp-ffm')
+
+    // This is only needed for ForeignRegistrationFeature and the native-image build
+    implementation group: 'org.graalvm.sdk', name: 'nativeimage', version: '24.0.0'
 }
 
 jar {
     inputs.property("moduleName", moduleName)
     manifest {
         attributes  'Implementation-Title': 'Example secp256k1-jdk Apps',
+                'Main-Class': application.mainClass,
                 'Implementation-Version': archiveVersion.get()
     }
 }
@@ -32,6 +36,11 @@ run {
     jvmArgs += '--enable-native-access=org.bitcoinj.secp.ffm'
 }
 
+configurations {
+    nativeToolImplementation.extendsFrom implementation
+    nativeToolRuntimeOnly.extendsFrom runtimeOnly
+}
+
 tasks.register('runEcdsa', JavaExec) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(javaToolchainVersion)
@@ -41,4 +50,62 @@ tasks.register('runEcdsa', JavaExec) {
     mainModule = 'org.bitcoinj.secp.examples'
     mainClass = 'org.bitcoinj.secp.examples.Ecdsa'
     jvmArgs += '--enable-native-access=org.bitcoinj.secp.ffm'
+}
+
+tasks.register('nativeCompile') {
+    dependsOn 'nativeCompileSchnorr', 'nativeCompileEcdsa'
+}
+
+// Compile a native image using GraalVM's native-image tool
+// Graal must be installed at $GRAALVM_HOME
+tasks.register('nativeCompileSchnorr', Exec) {
+    dependsOn jar
+    workingDir = projectDir
+    executable = "${System.env.GRAALVM_HOME}/bin/native-image"
+    args = ['--verbose',
+            '--no-fallback',
+            '--module', 'org.bitcoinj.secp.examples/org.bitcoinj.secp.examples.Schnorr',
+            '--module-path', jar.archiveFile.get(),
+            '--module-path', "${-> configurations.nativeToolImplementation.asPath}", // Lazy configuration resolution
+            '--module-path', "${-> configurations.nativeToolRuntimeOnly.asPath}",   // Lazy configuration resolution
+            '--add-modules', 'org.bitcoinj.secp.ffm',
+            '--enable-native-access=org.bitcoinj.secp.ffm',
+            '-H:Path=build',
+            '-H:Name=schnorr-example',
+            '-H:+ForeignAPISupport',
+            '-H:+SharedArenaSupport',
+            '-H:-CheckToolchain',
+            '--features=org.bitcoinj.secp.examples.ForeignRegistrationFeature',
+            '--enable-native-access=ALL-UNNAMED',
+            '-H:+ReportUnsupportedElementsAtRuntime',
+            '-H:+ReportExceptionStackTraces'
+    ]
+}
+
+// Compile a native image using GraalVM's native-image tool
+// Graal must be installed at $GRAALVM_HOME
+// THIS IS NOT WORKING YET, THERE'S A PROBLEM AT RUNTIME:
+// "Cannot perform downcall with leaf type (long,long,long,long,long)int as it was not registered at compilation time"
+tasks.register('nativeCompileEcdsa', Exec) {
+    dependsOn jar
+    workingDir = projectDir
+    executable = "${System.env.GRAALVM_HOME}/bin/native-image"
+    args = ['--verbose',
+            '--no-fallback',
+            '--module', 'org.bitcoinj.secp.examples/org.bitcoinj.secp.examples.Ecdsa',
+            '--module-path', jar.archiveFile.get(),
+            '--module-path', "${-> configurations.nativeToolImplementation.asPath}", // Lazy configuration resolution
+            '--module-path', "${-> configurations.nativeToolRuntimeOnly.asPath}",   // Lazy configuration resolution
+            '--add-modules', 'org.bitcoinj.secp.ffm',
+            '--enable-native-access=org.bitcoinj.secp.ffm',
+            '-H:Path=build',
+            '-H:Name=ecdsa-example',
+            '-H:+ForeignAPISupport',
+            '-H:+SharedArenaSupport',
+            '-H:-CheckToolchain',
+            '--features=org.bitcoinj.secp.examples.ForeignRegistrationFeature',
+            '--enable-native-access=ALL-UNNAMED',
+            '-H:+ReportUnsupportedElementsAtRuntime',
+            '-H:+ReportExceptionStackTraces'
+    ]
 }

--- a/secp-examples-java/src/main/java/module-info.java
+++ b/secp-examples-java/src/main/java/module-info.java
@@ -17,4 +17,5 @@
 module org.bitcoinj.secp.examples {
     requires org.bitcoinj.secp.api;
     requires org.jspecify;
+    requires org.graalvm.nativeimage;
 }

--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/ForeignRegistrationFeature.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/ForeignRegistrationFeature.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-2024 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.examples;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeForeignAccess;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+
+import static java.lang.foreign.ValueLayout.*;
+
+/**
+ *
+ */
+public class ForeignRegistrationFeature implements Feature {
+    public void duringSetup(Feature.DuringSetupAccess access) {
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid());
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_LONG, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(ADDRESS, JAVA_INT, JAVA_INT), Linker.Option.firstVariadicArg(1));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_INT), Linker.Option.captureCallState("errno"));
+    }
+}


### PR DESCRIPTION
To build native image use: 

./gradlew secp-examples-java:nativeCompile

Currently requires Graal JDK 25-ea