### PR TITLE
Result: rename unwrap() to get()

### DIFF
--- a/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/Result.java
+++ b/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/Result.java
@@ -41,10 +41,10 @@ public sealed interface Result<T> {
 
     // TODO: define well-known error codes and messages and map between them
     // TODO: Consider creating an enum (or other type) for results rather than using int.
-    default T unwrap() {
-        return unwrap("Error");
+    default T get() {
+        return get("Error");
     }
-    default T unwrap(String message) {
+    default T get(String message) {
         if (this instanceof Ok<T> ok) {
             return ok.result();
         } else if (this instanceof Err<T> err) {

--- a/secp256k1-bitcoinj/src/test/java/org/bitcoinj/secp256k1/bitcoinj/AddressTest.java
+++ b/secp256k1-bitcoinj/src/test/java/org/bitcoinj/secp256k1/bitcoinj/AddressTest.java
@@ -90,7 +90,7 @@ public class AddressTest {
         Address tapRootAddress;
         try (Secp256k1 secp = new Bouncy256k1()) {
             byte[] serial = HexFormat.of().parseHex("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
-            P256K1XOnlyPubKey xOnlyKey = P256K1XOnlyPubKey.parse(serial).unwrap();
+            P256K1XOnlyPubKey xOnlyKey = P256K1XOnlyPubKey.parse(serial).get();
             BigInteger tweakInt = calcTweak(xOnlyKey);
             P256k1PubKey G = new PubKeyPojo(Secp256k1.EC_PARAMS.getGenerator());
             P256k1PubKey P2 = secp.ecPubKeyTweakMul(G, tweakInt);

--- a/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Ecdsa.java
+++ b/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Ecdsa.java
@@ -61,24 +61,24 @@ public class Ecdsa {
 
             /* Generate an ECDSA signature using the RFC-6979 safe default nonce.
              * Signing with a valid context, verified secret key and the default nonce function should never fail. */
-            SignatureData sig = secp.ecdsaSign(msg_hash, privKey).unwrap();
+            SignatureData sig = secp.ecdsaSign(msg_hash, privKey).get();
 
             /* Serialize the signature in a compact form. Should always succeed according to
              the documentation in secp256k1.h. */
-            CompressedSignatureData serialized_signature = secp.ecdsaSignatureSerializeCompact(sig).unwrap();
+            CompressedSignatureData serialized_signature = secp.ecdsaSignatureSerializeCompact(sig).get();
 
             /* === Verification === */
 
             /* Deserialize the signature. This will return empty if the signature can't be parsed correctly. */
-            SignatureData sig2 = secp.ecdsaSignatureParseCompact(serialized_signature).unwrap();
+            SignatureData sig2 = secp.ecdsaSignatureParseCompact(serialized_signature).get();
             assert(Arrays.equals(sig.bytes(), sig2.bytes()));
 
             /* Deserialize the public key. This will return empty if the public key can't be parsed correctly. */
-            P256k1PubKey pubkey2 = secp.ecPubKeyParse(compressed_pubkey).unwrap();
+            P256k1PubKey pubkey2 = secp.ecPubKeyParse(compressed_pubkey).get();
             assert(pubkey.getW().equals(pubkey2.getW()));
 
             /* Verify a signature. This will return true if it's valid and false if it's not. */
-            boolean is_signature_valid = secp.ecdsaVerify(sig2, msg_hash, pubkey2).unwrap();
+            boolean is_signature_valid = secp.ecdsaVerify(sig2, msg_hash, pubkey2).get();
 
             System.out.printf("Is the signature valid? %s\n", is_signature_valid);
             System.out.printf("Secret Key: %s\n", privKey.getS().toString(16));

--- a/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Schnorr.java
+++ b/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Schnorr.java
@@ -58,12 +58,12 @@ public class Schnorr {
 
             /* === Verification === */
 
-            P256K1XOnlyPubKey xOnly2 = P256K1XOnlyPubKey.parse(serializedXOnly).unwrap();
+            P256K1XOnlyPubKey xOnly2 = P256K1XOnlyPubKey.parse(serializedXOnly).get();
 
             /* Compute the tagged hash on the received message using the same tag as the signer. */
             byte[] msg_hash2 = secp.taggedSha256(tag, msg);
 
-            boolean is_signature_valid = secp.schnorrSigVerify(signature, msg_hash2, xOnly2).unwrap();
+            boolean is_signature_valid = secp.schnorrSigVerify(signature, msg_hash2, xOnly2).get();
 
             System.out.printf("Is the signature valid? %s\n", is_signature_valid);
             System.out.printf("Secret Key: %s\n", keyPair.getS().toString(16));

--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
@@ -52,22 +52,22 @@ object Ecdsa {
 
             /* Generate an ECDSA signature using the RFC-6979 safe default nonce.
              * Signing with a valid context, verified secret key and the default nonce function should never fail. */
-            val sig = secp.ecdsaSign(msg_hash, privKey).unwrap()
+            val sig = secp.ecdsaSign(msg_hash, privKey).get()
 
             /* Serialize the signature in a compact form. Should always succeed according to
              the documentation in secp256k1.h. */
-            val serialized_signature = secp.ecdsaSignatureSerializeCompact(sig).unwrap()
+            val serialized_signature = secp.ecdsaSignatureSerializeCompact(sig).get()
 
             /* === Verification === */
 
             /* Deserialize the signature. This will return empty if the signature can't be parsed correctly. */
-            val sig2 = secp.ecdsaSignatureParseCompact(serialized_signature).unwrap()
+            val sig2 = secp.ecdsaSignatureParseCompact(serialized_signature).get()
             assert(sig.bytes().contentEquals(sig2.bytes()))
             /* Deserialize the public key. This will return empty if the public key can't be parsed correctly. */
-            val pubkey2 = secp.ecPubKeyParse(compressed_pubkey).unwrap()
+            val pubkey2 = secp.ecPubKeyParse(compressed_pubkey).get()
             assert(pubkey.w == pubkey2.w)
             /* Verify a signature. This will return true if it's valid and false if it's not. */
-            val is_signature_valid = secp.ecdsaVerify(sig2, msg_hash, pubkey2).unwrap()
+            val is_signature_valid = secp.ecdsaVerify(sig2, msg_hash, pubkey2).get()
 
             System.out.printf("Is the signature valid? %s\n", is_signature_valid)
             System.out.printf("Secret Key: %s\n", privKey.s.toString(16))

--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
@@ -51,12 +51,12 @@ object Schnorr {
             val signature = secp.schnorrSigSign32(msg_hash, keyPair)
 
             /* === Verification === */
-            val xOnly2 : P256K1XOnlyPubKey = P256K1XOnlyPubKey.parse(serializedXOnly).unwrap()
+            val xOnly2 : P256K1XOnlyPubKey = P256K1XOnlyPubKey.parse(serializedXOnly).get()
 
             /* Compute the tagged hash on the received message using the same tag as the signer. */
             val msg_hash2 = secp.taggedSha256(tag, msg)
 
-            val is_signature_valid = secp.schnorrSigVerify(signature, msg_hash2, xOnly2).unwrap()
+            val is_signature_valid = secp.schnorrSigVerify(signature, msg_hash2, xOnly2).get()
 
             System.out.printf("Is the signature valid? %s\n", is_signature_valid)
             System.out.printf("Secret Key: %s\n", keyPair.s.toString(16))


### PR DESCRIPTION
I borrowed `unwrap()` from Rust. `get()` is more consistent with standard Java classes.  (And 3 fewer characters 🤓)