### PR TITLE
build.gradle: Enable reading toolchain vendor from gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
             //  See `gradle.properties` for the setting of `javaToolchainVersion` and other setting that are used
             // to find and/or download JDK versions.
             languageVersion = JavaLanguageVersion.of(javaToolchainVersion)
-            // vendor = JvmVendorSpec.matching(javaToolchainVendor)
+            vendor = JvmVendorSpec.matching(javaToolchainVendor)
         }
     }
 


### PR DESCRIPTION
This allows users to override the JDK vendor by editing gradle.properties.

For example, if you have installed JDK 22 via Nix and set the `JDK22` environment variable to point to the Nix-installed JDK, but you have other version 22 JDKs installed in places where Gradle might look, you can set the vendor to `Azul` to convince Gradle to use it (unless you have another copy of an Azul JDK 22.)