### PR TITLE
extract-headers.sh: Use .nix-profile path for headers, add comment

### DIFF
--- a/extract-headers.sh
+++ b/extract-headers.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
-NIX_STORE="/nix/store"
-LIB_PKG="secp256k1-0.4.0"
-HASH="j9mf1fh4wbb8c3x1zwqfs218bhml1rbw"
-SECP_PATH=$NIX_STORE/$HASH-$LIB_PKG
+# This script assumes you are using Nix Packages with `experimental-features = nix-command flakes`
+# and have used `nix profile install secp256k1` to install the secp256k1 library and headers.
+# It also assumes you have `jextract` version 22 in your `$PATH`. (To install with Nix, use
+# `nix profile install jextract`)
+INC_PATH="$HOME/.nix-profile/include/"
 mkdir -p build
-./bin/jextract-22/bin/jextract --target-package org.bitcoinj.secp256k1.foreign.jextract \
+jextract --target-package org.bitcoinj.secp256k1.foreign.jextract \
         --output build \
         --use-system-load-library \
         -lsecp256k1 \
         --header-class-name secp256k1_h \
-        $SECP_PATH/include/secp256k1_schnorrsig.h
+        $INC_PATH/secp256k1_schnorrsig.h


### PR DESCRIPTION
* Search for headers in $HOME/.nix-profile/include/ rather than in /nix/store with a version and hash dependency
* Add comment explaining script's assumptions