### PR TITLE
flake.nix: Nix develop with JDK22 configured in javaToolchains

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,11 +60,9 @@ The SECG secp256K1 curve was removed from Java in the JDK 16 release (see https:
 
 The current build requires JDK 21 and JDK 22 installed to run.
 
-The build also requires an installed binary of `secp256k1` version 0.4.1 and we recommend using Nix to install it.
-
 == Installing libsecp256k into your profile with Nix
 
-This assumes you are using Nix with `experimental-features = nix-command flakes`:
+We assume you are using Nix with `experimental-features = nix-command flakes`:
 
 . `nix profile install nixpkgs#secp256k1`
 . Verify that the secp256k1 library is in your `~/.nix-profile/lib` directory.
@@ -75,7 +73,9 @@ path to your location.
 
 == Building with Gradle Wrapper
 
-* `./gradlew build`
+Make sure you have installed the current version (0.4.1) of `secp256k1` with `nix profile install nixpkgs#secp256k1`
+
+. `./gradlew build`
 
 == Running the Schnorr Example with Gradle Wrapper
 
@@ -101,17 +101,23 @@ Run the script:
 
 == Building with Nix
 
-NOTE:: This is currently broken after we switched from using JDK 21 in preview mode to JDK 22. We are waiting for Gradle 8.7 in Nixpkgs.
+NOTE:: We currently only support setting up a development environment with Nix. In the future we hope to support a full Nix build.
+
+To start a development shell with all build prerequisites installed and run the Gradle build:
 
 . `nix develop`
 . `gradle build`
 
-== Building Headers with Nix
+== Extracting Headers with Nix
 
-NOTE:: These instructions assume you are using `experimental-features = nix-command flakes`.
+To extract the libsecp256k1 headers into Java classes via `jextract` using the `extract-header.sh` script:
 
 . `nix develop`
 . `./extract-headers.sh`
+
+The extracted headers will be writen to `./build/org/bitcoinj/secp256k1/foreign/jextract`. You can compare the generated headers with the checked-in headers with:
+
+. `diff -r secp256k1-foreign/src/main/java/org/bitcoinj/secp256k1/foreign/jextract build/org/bitcoinj/secp256k1/foreign/jextract`
 
 
 == Reporting a vulnerability

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -49,9 +49,11 @@
 #            ];
           inputsFrom = with pkgs ; [ secp256k1 ];
           packages = with pkgs ; [
-                jdk21       # Migrate to JDK 22 when possible, see https://github.com/NixOS/nixpkgs/issues/271971
-                jextract
-                gradle
+                jdk22                # JDK 22 will be in $JAVA_HOME (and in javaToolchains)
+                jextract             # jextract (Nix package) contains a jlinked executable and bundles its own JDK 22
+                (gradle.override {   # Gradle 8.7 (Nix package) depends-on and directly uses JDK 21 to launch Gradle itself
+                    javaToolchains = [ jdk22 ];     # Put JDK 22 in Gradle's javaToolchain configuration
+                })
             ];
         };
 

--- a/secp256k1-examples-kotlin/build.gradle
+++ b/secp256k1-examples-kotlin/build.gradle
@@ -15,7 +15,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(22)
 }
 
 application {


### PR DESCRIPTION
This restores the operation of `nix develop` to the level of functionality it had when we were building using JDK 21 with _Preview_ enabled. Now that `jdk22`, Gradle 8.7, and the latest (JDK22-based) `jextract` are all available in Nixpkgs `unstable` we have everything working again.

* `flake.lock` is updated to get the current `nixos-unstable` branch with Gradle 8.7, etc.
* `Secp256k1-examples-kotlin/build.gradle` needs to run with JDK 22 because we only want to require a single JDK (22) for use by javaToolchains. (But we must continue to tell the Kotlin compiler to target JDK 21 for now)
* Update the README