### PR TITLE
Implement Provider interface for modular and non-modular apps.

### DIFF
--- a/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/Secp256k1.java
+++ b/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/Secp256k1.java
@@ -75,4 +75,21 @@ public interface Secp256k1 extends Closeable {
      * Override close and declare that no checked exceptions are thrown
      */
     void close();
+
+    /**
+     * Get the default implementation
+     * @return A Secp256k1 instance using the <i>default</i> implementation
+     */
+    static Secp256k1 get() {
+        return Secp256k1Provider.find().get();
+    }
+
+    /**
+     * Get implementation by name
+     * @param name implementation name
+     * @return A Secp256k1 instance using the <i>default</i> implementation
+     */
+    static Secp256k1 getByName(String name) {
+        return Secp256k1Provider.byName(name).get();
+    }
 }

--- a/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/Secp256k1Provider.java
+++ b/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/Secp256k1Provider.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023-2024 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp256k1.api;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Predicate;
+
+/**
+ *
+ */
+public interface Secp256k1Provider {
+    /**
+     * Implementations must implement this method to return a unique name
+     * @return A unique name for this Secp256k1 implementation
+     */
+    String name();
+
+    /**
+     * @return A Secp256k1 instance
+     */
+    Secp256k1 get();
+
+    /**
+     * Find a Secp256k1Provider by name
+     *
+     * @param name Name (e.g. "ffm" or "bouncy-castle")
+     * @return an Secp256k1Provider instance
+     * @throws NoSuchElementException if not found
+     */
+    static Secp256k1Provider byName(String name) {
+        return findFirst(provider -> provider.name().equals(name))
+                .orElseThrow(() -> new NoSuchElementException("Provider " + name + " not found."));
+    }
+
+    /**
+     * Find default Secp256k1Provider
+     *
+     * @return an Secp256k1Provider instance
+     * @throws NoSuchElementException if not found
+     */
+    static Secp256k1Provider find() {
+        return findFirst(Secp256k1Provider::defaultFilter)
+                .orElseThrow(() -> new NoSuchElementException("Default Provider not found."));
+    }
+
+    /**
+     * Find a Secp256k1Provider using a custom predicate
+     * @param filter predicate for finding a provider
+     * @return the <b>first</b> provider matching the predicate, if any
+     */
+    static Optional<Secp256k1Provider> findFirst(Predicate<Secp256k1Provider> filter) {
+        ServiceLoader<Secp256k1Provider> loader = ServiceLoader.load(Secp256k1Provider.class);
+        return loader.stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(filter)
+                .findFirst();
+    }
+
+    /**
+     * Find the default provider. This is currently the "ffm" (foreign) provider.
+     * @param provider a candidate provider
+     * @return true if it should be "found"
+     */
+    private static boolean defaultFilter(Secp256k1Provider provider) {
+        return provider.name().equals("ffm");
+    }
+}

--- a/secp256k1-bitcoinj/src/test/java/org/bitcoinj/secp256k1/bitcoinj/AddressTest.java
+++ b/secp256k1-bitcoinj/src/test/java/org/bitcoinj/secp256k1/bitcoinj/AddressTest.java
@@ -28,7 +28,6 @@ import org.bitcoinj.secp256k1.bouncy.Bouncy256k1;
 import org.bitcoinj.secp256k1.bouncy.BouncyPrivKey;
 import org.bitcoinj.secp256k1.bouncy.BouncyPubKey;
 import org.bitcoinj.secp256k1.foreign.PubKeyPojo;
-import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,7 +50,7 @@ public class AddressTest {
     @ParameterizedTest(name = "key {0} -> Address {1}")
     void createAddressTest(BigInteger key, String address) throws Exception {
         Address tapRootAddress;
-        try (Secp256k1 secp = new Secp256k1Foreign()) {
+        try (Secp256k1 secp = Secp256k1.get()) {
             P256K1KeyPair keyPair = secp.ecKeyPairCreate(new BouncyPrivKey(key));
             WitnessMaker maker = new WitnessMaker(secp);
 //            P256K1XOnlyPubKey xOnlyKey = keyPair.getPublic().getXOnly();
@@ -111,7 +110,7 @@ public class AddressTest {
     @Test
     void createAddressTest2() throws Exception {
         Address tapRootAddress;
-        try (Secp256k1 secp = new Secp256k1Foreign()) {
+        try (Secp256k1 secp = Secp256k1.get()) {
             BigInteger internalPubKey = new BigInteger("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d", 16);
             byte[] compressed = new byte[33];
             compressed[0] = 0x02;

--- a/secp256k1-bouncy/src/main/java/module-info.java
+++ b/secp256k1-bouncy/src/main/java/module-info.java
@@ -16,4 +16,6 @@
 module org.bitcoinj.secp256k1.bouncy {
     requires org.bitcoinj.secp256k1.api;
     requires org.bouncycastle.provider;
+
+    provides org.bitcoinj.secp256k1.api.Secp256k1Provider with org.bitcoinj.secp256k1.bouncy.BouncyProvider;
 }

--- a/secp256k1-bouncy/src/main/java/org/bitcoinj/secp256k1/bouncy/BouncyProvider.java
+++ b/secp256k1-bouncy/src/main/java/org/bitcoinj/secp256k1/bouncy/BouncyProvider.java
@@ -13,8 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module org.bitcoinj.secp256k1.api {
-    exports org.bitcoinj.secp256k1.api;
+package org.bitcoinj.secp256k1.bouncy;
 
-    uses org.bitcoinj.secp256k1.api.Secp256k1Provider;
+import org.bitcoinj.secp256k1.api.Secp256k1;
+import org.bitcoinj.secp256k1.api.Secp256k1Provider;
+
+/**
+ *
+ */
+public class BouncyProvider implements Secp256k1Provider {
+    @Override
+    public String name() {
+        return "bouncy-castle";
+    }
+
+    @Override
+    public Secp256k1 get() {
+        return new Bouncy256k1();
+    }
 }

--- a/secp256k1-bouncy/src/main/resources/META-INF/services/org.bitcoinj.secp256k1.api.Secp256k1Provider
+++ b/secp256k1-bouncy/src/main/resources/META-INF/services/org.bitcoinj.secp256k1.api.Secp256k1Provider
@@ -1,0 +1,1 @@
+org.bitcoinj.secp256k1.bouncy.BouncyProvider

--- a/secp256k1-examples-java/build.gradle
+++ b/secp256k1-examples-java/build.gradle
@@ -11,8 +11,8 @@ ext.moduleName = 'org.bitcoinj.secp256k1.examples'
 
 dependencies {
     implementation project(':secp256k1-api')
-    implementation project(':secp256k1-bouncy')
-    implementation project(':secp256k1-foreign')
+    runtimeOnly project(':secp256k1-bouncy')
+    runtimeOnly project(':secp256k1-foreign')
 }
 
 jar {
@@ -24,6 +24,7 @@ jar {
 }
 
 application {
+    mainModule = 'org.bitcoinj.secp256k1.examples'
 //    mainClass = 'org.bitcoinj.secp256k1.examples.Ecdsa'
     mainClass = 'org.bitcoinj.secp256k1.examples.Schnorr'
 }
@@ -31,5 +32,5 @@ application {
 run {
     def userHome = System.getProperty("user.home")
     systemProperty "java.library.path", findProperty("javaPath") ?: "${userHome}/.nix-profile/lib"
-    jvmArgs += '--enable-native-access=ALL-UNNAMED'
+    jvmArgs += '--enable-native-access=org.bitcoinj.secp256k1.foreign'
 }

--- a/secp256k1-examples-java/src/main/java/module-info.java
+++ b/secp256k1-examples-java/src/main/java/module-info.java
@@ -14,6 +14,5 @@
  * limitations under the License.
  */
 module org.bitcoinj.secp256k1.examples {
-    requires org.bitcoinj.secp256k1.foreign;
     requires org.bitcoinj.secp256k1.api;
 }

--- a/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Ecdsa.java
+++ b/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Ecdsa.java
@@ -19,9 +19,8 @@ import org.bitcoinj.secp256k1.api.CompressedPubKeyData;
 import org.bitcoinj.secp256k1.api.CompressedSignatureData;
 import org.bitcoinj.secp256k1.api.P256k1PrivKey;
 import org.bitcoinj.secp256k1.api.P256k1PubKey;
+import org.bitcoinj.secp256k1.api.Secp256k1;
 import org.bitcoinj.secp256k1.api.SignatureData;
-import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign;
-import org.bitcoinj.secp256k1.foreign.jextract.secp256k1_h;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -42,7 +41,7 @@ public class Ecdsa {
     public static void main(String[] args) {
         System.out.println("Running secp256k1-jdk Ecdsa example...");
         /* Use a java try-with-resources to allocate and cleanup -- secp256k1_context_destroy is automatically called */
-        try (Secp256k1Foreign secp = new Secp256k1Foreign()) {
+        try (Secp256k1 secp = Secp256k1.get()) {
             /* === Key Generation === */
 
             /* Return a non-zero, in-range private key */
@@ -53,7 +52,7 @@ public class Ecdsa {
             P256k1PubKey pubkey = secp.ecPubKeyCreate(privKey);
 
             /* Serialize the pubkey in a compressed form(33 bytes). */
-            CompressedPubKeyData compressed_pubkey = secp.ecPubKeySerialize(pubkey, secp256k1_h.SECP256K1_EC_COMPRESSED());
+            CompressedPubKeyData compressed_pubkey = secp.ecPubKeySerialize(pubkey, (int)2L /* secp256k1_h.SECP256K1_EC_COMPRESSED() */);
 
             /* === Signing === */
 

--- a/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Schnorr.java
+++ b/secp256k1-examples-java/src/main/java/org/bitcoinj/secp256k1/examples/Schnorr.java
@@ -18,7 +18,7 @@ package org.bitcoinj.secp256k1.examples;
 import org.bitcoinj.secp256k1.api.P256K1KeyPair;
 import org.bitcoinj.secp256k1.api.P256K1XOnlyPubKey;
 import org.bitcoinj.secp256k1.api.P256k1PubKey;
-import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign;
+import org.bitcoinj.secp256k1.api.Secp256k1;
 
 import java.util.HexFormat;
 
@@ -34,7 +34,7 @@ public class Schnorr {
     public static void main(String[] args) {
         System.out.println("Running secp256k1-jdk Schnorr example...");
         /* Use a java try-with-resources to allocate and cleanup -- secp256k1_context_destroy is automatically called */
-        try (Secp256k1Foreign secp = new Secp256k1Foreign()) {
+        try (Secp256k1 secp = Secp256k1.get()) {
             /* === Key Generation === */
 
             /* Return a non-zero, in-range private key */

--- a/secp256k1-examples-kotlin/build.gradle
+++ b/secp256k1-examples-kotlin/build.gradle
@@ -5,9 +5,8 @@ plugins {
 
 dependencies {
     implementation project(':secp256k1-api')
-    //implementation project(':secp256k1-bouncy')
-    implementation project(':secp256k1-foreign')
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
+    runtimeOnly project(':secp256k1-bouncy')
+    runtimeOnly project(':secp256k1-foreign')
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -19,7 +18,7 @@ kotlin {
 }
 
 application {
-    //mainClass = 'org.bitcoinj.secp256k1.kotlin.examples.Ecdsa'
+//    mainClass = 'org.bitcoinj.secp256k1.kotlin.examples.Ecdsa'
     mainClass = 'org.bitcoinj.secp256k1.kotlin.examples.Schnorr'
 }
 

--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
@@ -15,7 +15,7 @@
  */
 package org.bitcoinj.secp256k1.kotlin.examples
 
-import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign
+import org.bitcoinj.secp256k1.api.Secp256k1
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.*
@@ -35,7 +35,7 @@ object Ecdsa {
     @JvmStatic
     fun main(args: Array<String>) {
         println("Running secp256k1-jdk Ecdsa example...")
-        Secp256k1Foreign().use { secp ->
+        Secp256k1.getByName("ffm").use { secp ->
             /* === Key Generation === */
             /* Return a non-zero, in-range private key */
             val privKey = secp.ecPrivKeyCreate()

--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
@@ -16,7 +16,7 @@
 package org.bitcoinj.secp256k1.kotlin.examples
 
 import org.bitcoinj.secp256k1.api.P256K1XOnlyPubKey
-import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign
+import org.bitcoinj.secp256k1.api.Secp256k1
 import java.util.*
 
 /**
@@ -31,7 +31,7 @@ object Schnorr {
     @JvmStatic
     fun main(args: Array<String>) {
         println("Running secp256k1-jdk Schnorr example...")
-        Secp256k1Foreign().use { secp ->
+        Secp256k1.getByName("ffm").use { secp ->
             /* === Key Generation === */
             /* Return a non-zero, in-range private key */
             val keyPair = secp.ecKeyPairCreate()

--- a/secp256k1-foreign/src/main/java/module-info.java
+++ b/secp256k1-foreign/src/main/java/module-info.java
@@ -18,4 +18,6 @@ module org.bitcoinj.secp256k1.foreign {
 
     exports org.bitcoinj.secp256k1.foreign;
     exports org.bitcoinj.secp256k1.foreign.jextract;
+
+    provides org.bitcoinj.secp256k1.api.Secp256k1Provider with org.bitcoinj.secp256k1.foreign.ForeignProvider;
 }

--- a/secp256k1-foreign/src/main/java/org/bitcoinj/secp256k1/foreign/ForeignProvider.java
+++ b/secp256k1-foreign/src/main/java/org/bitcoinj/secp256k1/foreign/ForeignProvider.java
@@ -1,3 +1,8 @@
+package org.bitcoinj.secp256k1.foreign;
+
+import org.bitcoinj.secp256k1.api.Secp256k1;
+import org.bitcoinj.secp256k1.api.Secp256k1Provider;
+
 /*
  * Copyright 2023-2024 secp256k1-jdk Developers.
  *
@@ -13,8 +18,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module org.bitcoinj.secp256k1.api {
-    exports org.bitcoinj.secp256k1.api;
+public class ForeignProvider implements Secp256k1Provider {
+    @Override
+    public String name() {
+        return "ffm";
+    }
 
-    uses org.bitcoinj.secp256k1.api.Secp256k1Provider;
+    @Override
+    public Secp256k1 get() {
+        return new Secp256k1Foreign();
+    }
 }

--- a/secp256k1-foreign/src/main/resources/META-INF/services/org.bitcoinj.secp256k1.api.Secp256k1Provider
+++ b/secp256k1-foreign/src/main/resources/META-INF/services/org.bitcoinj.secp256k1.api.Secp256k1Provider
@@ -1,0 +1,1 @@
+org.bitcoinj.secp256k1.foreign.ForeignProvider


### PR DESCRIPTION
This makes it possible to build applications and libraries with a sole compile-time dependency on `secp256k1-api`. At runtime either the native (aka foreign or ffm) or Bouncy Castle implementation (when complete) can be "used".

* Define the Secp256k1Provider interface and two implementations with no-arg constructors.
* Add the get() and getByName() methods to the Secp256k1 interface
* Update module-info files with `provides` and `uses` statements. 
* Add resource files for service provider location in non-modular apps.
* Remove direct dependencies on implementations from the examples
* Run the Java example application as a modular application
* ~~Switch the Kotlin example default app to Ecdsa.java~~