### PR TITLE
build.gradle: remove bitcoinj test dependency from subprojects closure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,6 @@ subprojects {
     }
 
     dependencies {
-        testImplementation("org.bitcoinj:bitcoinj-core:0.17-alpha3");
-
         testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
         testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
         testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"


### PR DESCRIPTION
This is unneeded as bitcoinj is only used in one submodule and is declared in that modules build.gradle.