### PR TITLE
Kotlin examples: switch to using the FFM (foreign) implementation

### DIFF
--- a/secp256k1-examples-kotlin/build.gradle
+++ b/secp256k1-examples-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.9.23"
+    id "org.jetbrains.kotlin.jvm" version "2.0.0-RC1"
     id 'application'
 }
 
@@ -11,7 +11,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.release = 21    // Temporary, until Kotlin supports JDK 22
+    options.release = 22
 }
 
 kotlin {

--- a/secp256k1-examples-kotlin/build.gradle
+++ b/secp256k1-examples-kotlin/build.gradle
@@ -5,8 +5,8 @@ plugins {
 
 dependencies {
     implementation project(':secp256k1-api')
-    implementation project(':secp256k1-bouncy')
-    //implementation project(':secp256k1-foreign')
+    //implementation project(':secp256k1-bouncy')
+    implementation project(':secp256k1-foreign')
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
 }
 

--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Ecdsa.kt
@@ -15,7 +15,7 @@
  */
 package org.bitcoinj.secp256k1.kotlin.examples
 
-import org.bitcoinj.secp256k1.bouncy.Bouncy256k1
+import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.*
@@ -35,7 +35,7 @@ object Ecdsa {
     @JvmStatic
     fun main(args: Array<String>) {
         println("Running secp256k1-jdk Ecdsa example...")
-        Bouncy256k1().use { secp ->
+        Secp256k1Foreign().use { secp ->
             /* === Key Generation === */
             /* Return a non-zero, in-range private key */
             val privKey = secp.ecPrivKeyCreate()

--- a/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
+++ b/secp256k1-examples-kotlin/src/main/java/org/bitcoinj/secp256k1/kotlin/examples/Schnorr.kt
@@ -16,7 +16,7 @@
 package org.bitcoinj.secp256k1.kotlin.examples
 
 import org.bitcoinj.secp256k1.api.P256K1XOnlyPubKey
-import org.bitcoinj.secp256k1.bouncy.Bouncy256k1
+import org.bitcoinj.secp256k1.foreign.Secp256k1Foreign
 import java.util.*
 
 /**
@@ -31,7 +31,7 @@ object Schnorr {
     @JvmStatic
     fun main(args: Array<String>) {
         println("Running secp256k1-jdk Schnorr example...")
-        Bouncy256k1().use { secp ->
+        Secp256k1Foreign().use { secp ->
             /* === Key Generation === */
             /* Return a non-zero, in-range private key */
             val keyPair = secp.ecKeyPairCreate()


### PR DESCRIPTION
Now that Kotlin supports JDK 22 the Kotlin examples should use the implementation that is complete and actually works.

This is a child of PR #44 
