### PR TITLE
Move enable-native-access jvmArgs into examples-java/build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,15 +41,10 @@ subprojects {
         useJUnitPlatform()
         def userHome = System.getProperty("user.home")
         systemProperty "java.library.path", findProperty("javaPath") ?: "${userHome}/.nix-profile/lib"
-        jvmArgs += '--enable-native-access=ALL-UNNAMED'
     }
 
     tasks.withType(JavaCompile).configureEach {
         options.release = 22
-    }
-
-    tasks.withType(JavaExec) {
-        jvmArgs += '--enable-native-access=ALL-UNNAMED'
     }
 }
 

--- a/secp256k1-examples-java/build.gradle
+++ b/secp256k1-examples-java/build.gradle
@@ -31,4 +31,5 @@ application {
 run {
     def userHome = System.getProperty("user.home")
     systemProperty "java.library.path", findProperty("javaPath") ?: "${userHome}/.nix-profile/lib"
+    jvmArgs += '--enable-native-access=ALL-UNNAMED'
 }


### PR DESCRIPTION
This simplifies the build and will also simplify a rebased PR #42