### PR TITLE
Kotlin example build.gradle: add enable-native-access

### DIFF
--- a/secp256k1-examples-kotlin/build.gradle
+++ b/secp256k1-examples-kotlin/build.gradle
@@ -26,5 +26,6 @@ application {
 run {
     def userHome = System.getProperty("user.home")
     systemProperty "java.library.path", findProperty("javaPath") ?: "${userHome}/.nix-profile/lib"
+    jvmArgs += '--enable-native-access=ALL-UNNAMED'
 }
 


### PR DESCRIPTION
This eliminates a warning displayed at runtime.