### PR TITLE
Kotlin example build.gradle: use Kotlin 2.0.0

### DIFF
--- a/secp256k1-examples-kotlin/build.gradle
+++ b/secp256k1-examples-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "2.0.0-RC1"
+    id "org.jetbrains.kotlin.jvm" version "2.0.0"
     id 'application'
 }
 


### PR DESCRIPTION
This PR started as an upgrade to RC2, but 2.0.0 final is out now, so I've updated and force-pushed.