### PR TITLE
P256K1XOnlyPubKey: convert from class to interface

### DIFF
--- a/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/P256K1XOnlyPubKey.java
+++ b/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/P256K1XOnlyPubKey.java
@@ -20,34 +20,63 @@ import java.math.BigInteger;
 /**
  *
  */
-public class P256K1XOnlyPubKey {
-    private final BigInteger x;
-
-    public P256K1XOnlyPubKey(P256k1PubKey pubKey) {
-        // Avoid using pubKey.getXOnly() and possible infinite recursion
-        this.x = pubKey.getW().getAffineX();
-    }
-
-    public /* package */ P256K1XOnlyPubKey(BigInteger x) {
-        this.x = x;
-    }
-
-
-    public BigInteger getX() {
-        return x;
-    }
+public interface P256K1XOnlyPubKey {
+    /**
+     * @return X as a {@link BigInteger}
+     */
+    BigInteger getX();
 
     /**
      * @return Big-endian, 32 bytes
      */
-    public byte[] getSerialized() {
-        return P256k1PubKey.integerTo32Bytes(x);
-    }
+    byte[] getSerialized();
 
-    public static Result<P256K1XOnlyPubKey> parse(byte[] serialized) {
+    /**
+     * Parses a serialized x-only pubkey and returns an instance of the default implementation
+     * @param serialized byte string in x-only pubkey serialization format
+     * @return an instance of the default implementation
+     */
+    static Result<P256K1XOnlyPubKey> parse(byte[] serialized) {
         BigInteger x = new BigInteger(1, serialized);
         return (x.compareTo((Secp256k1.FIELD.getP())) > 0)
                 ? Result.err(-1)
-                : Result.ok(new P256K1XOnlyPubKey(x));
+                : Result.ok(P256K1XOnlyPubKey.of(x));
+    }
+
+    /**
+     * @param x X as a {@link BigInteger}
+     * @return an instance of the default implementation
+     */
+    static P256K1XOnlyPubKey of(BigInteger x) {
+        return new P256K1XOnlyPubKeyImpl(x);
+    }
+
+    /**
+     * Default implementation. Currently used by all known implementations
+     */
+    class P256K1XOnlyPubKeyImpl implements P256K1XOnlyPubKey {
+        private final BigInteger x;
+
+        public P256K1XOnlyPubKeyImpl(P256k1PubKey pubKey) {
+            // Avoid using pubKey.getXOnly() and possible infinite recursion
+            this.x = pubKey.getW().getAffineX();
+        }
+
+        public P256K1XOnlyPubKeyImpl(BigInteger x) {
+            this.x = x;
+        }
+
+        @Override
+        public BigInteger getX() {
+            return x;
+        }
+
+        /**
+         * @return Big-endian, 32 bytes
+         */
+        @Override
+        public byte[] getSerialized() {
+            return P256k1PubKey.integerTo32Bytes(x);
+        }
     }
 }

--- a/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/P256k1PubKey.java
+++ b/secp256k1-api/src/main/java/org/bitcoinj/secp256k1/api/P256k1PubKey.java
@@ -74,7 +74,7 @@ public interface P256k1PubKey extends ECPublicKey {
     }
 
     default P256K1XOnlyPubKey getXOnly() {
-        return new P256K1XOnlyPubKey(this.getW().getAffineX());
+        return P256K1XOnlyPubKey.of(this.getW().getAffineX());
     }
 
     @Override

--- a/secp256k1-bitcoinj/src/test/java/org/bitcoinj/secp256k1/bitcoinj/AddressTest.java
+++ b/secp256k1-bitcoinj/src/test/java/org/bitcoinj/secp256k1/bitcoinj/AddressTest.java
@@ -118,7 +118,7 @@ public class AddressTest {
             System.arraycopy(xbytes, 0, compressed, 1, 32);
             ECKey ecKey = ECKey.fromPublicOnly(compressed);
             P256k1PubKey pubkey = new BouncyPubKey(ecKey.getPubKeyPoint());
-            P256K1XOnlyPubKey xOnlyKey = new P256K1XOnlyPubKey(internalPubKey);
+            P256K1XOnlyPubKey xOnlyKey = P256K1XOnlyPubKey.of(internalPubKey);
             BigInteger tweakInt = calcTweak(xOnlyKey);
             P256k1PubKey G = new PubKeyPojo(Secp256k1.EC_PARAMS.getGenerator());
             P256k1PubKey P2 = secp.ecPubKeyTweakMul(G, tweakInt);


### PR DESCRIPTION
Convert it from a class to an interface to allow API implementations the freedom of creating their own implementation, but provide a nested default implementation so they don't have to.