### PR TITLE
Add JSpecify Annotations: Everything NullMarked

### DIFF
--- a/secp256k1-api/build.gradle
+++ b/secp256k1-api/build.gradle
@@ -8,6 +8,10 @@ tasks.withType(JavaCompile).configureEach {
 
 ext.moduleName = 'org.bitcoinj.secp256k1.api'
 
+dependencies {
+    api("org.jspecify:jspecify:1.0.0")
+}
+
 jar {
     inputs.property("moduleName", moduleName)
     manifest {

--- a/secp256k1-api/src/main/java/module-info.java
+++ b/secp256k1-api/src/main/java/module-info.java
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@org.jspecify.annotations.NullMarked
 module org.bitcoinj.secp256k1.api {
+    requires org.jspecify;
+
     exports org.bitcoinj.secp256k1.api;
 
     uses org.bitcoinj.secp256k1.api.Secp256k1Provider;

--- a/secp256k1-bitcoinj/src/main/java/module-info.java
+++ b/secp256k1-bitcoinj/src/main/java/module-info.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@org.jspecify.annotations.NullMarked
 module org.bitcoinj.secp256k1.bitcoinj {
     requires org.bitcoinj.secp256k1.api;
     requires org.bitcoinj.secp256k1.foreign;
+    requires org.jspecify;
 }

--- a/secp256k1-bouncy/src/main/java/module-info.java
+++ b/secp256k1-bouncy/src/main/java/module-info.java
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@org.jspecify.annotations.NullMarked
 module org.bitcoinj.secp256k1.bouncy {
     requires org.bitcoinj.secp256k1.api;
     requires org.bouncycastle.provider;
+    requires org.jspecify;
 
     provides org.bitcoinj.secp256k1.api.Secp256k1Provider with org.bitcoinj.secp256k1.bouncy.BouncyProvider;
 }

--- a/secp256k1-examples-java/src/main/java/module-info.java
+++ b/secp256k1-examples-java/src/main/java/module-info.java
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@org.jspecify.annotations.NullMarked
 module org.bitcoinj.secp256k1.examples {
     requires org.bitcoinj.secp256k1.api;
+    requires org.jspecify;
 }

--- a/secp256k1-integration-test/src/test/java/org/bitcoinj/secp256k1/integration/package-info.java
+++ b/secp256k1-integration-test/src/test/java/org/bitcoinj/secp256k1/integration/package-info.java
@@ -14,12 +14,4 @@
  * limitations under the License.
  */
 @org.jspecify.annotations.NullMarked
-module org.bitcoinj.secp256k1.foreign {
-    requires org.bitcoinj.secp256k1.api;
-    requires org.jspecify;
-
-    exports org.bitcoinj.secp256k1.foreign;
-    exports org.bitcoinj.secp256k1.foreign.jextract;
-
-    provides org.bitcoinj.secp256k1.api.Secp256k1Provider with org.bitcoinj.secp256k1.foreign.ForeignProvider;
-}
+package org.bitcoinj.secp256k1.integration;

--- a/secp256k1-sandbox/src/main/java/module-info.java
+++ b/secp256k1-sandbox/src/main/java/module-info.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@org.jspecify.annotations.NullMarked
 module org.bitcoinj.secp256k1.sandbox {
     requires org.bitcoinj.secp256k1.api;
     requires org.bouncycastle.provider;
+    requires org.jspecify;
 }


### PR DESCRIPTION
All modules and packages are annotated with `@NullMarked` which means nothing is nullable by default. There are currently no exceptions.