### PR TITLE
Kotlin example build.gradle: use Kotlin 2.0.20-RC2

### DIFF
--- a/secp-examples-kotlin/build.gradle
+++ b/secp-examples-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "2.0.0"
+    id "org.jetbrains.kotlin.jvm" version "2.0.20-RC2"
     id 'application'
 }
 


### PR DESCRIPTION
This version of Kotlin is needed to support JSpecify and to officially support Gradle 8.6-8.8 (even though we're already using 8.10 without any apparent issues)