### PR TITLE
README: Update to reference secp256k1 0.5.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,7 +78,7 @@ path to your location.
 
 == Building with Gradle Wrapper
 
-Make sure you have installed version (0.4.1) of `secp256k1` with `nix profile install nixpkgs#secp256k1`
+Make sure you have installed version (0.5.0) of `secp256k1` with `nix profile install nixpkgs#secp256k1`
 
 . `./gradlew build`
 


### PR DESCRIPTION
0.5.0 is current on nixPkgs and is what we are testing with on CI. I have also verified it works locally on macOS and Linux.