### PR TITLE
Schnorr.java,Ecdsa.java: Use println and + concatenation operator

### DIFF
--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
@@ -77,11 +77,11 @@ public class Ecdsa {
             /* Verify a signature. This will return true if it's valid and false if it's not. */
             boolean is_signature_valid = secp.ecdsaVerify(sig2, msg_hash, pubkey2).get();
 
-            System.out.printf("Is the signature valid? %s\n", is_signature_valid);
-            System.out.printf("Secret Key: %s\n", privKey.getS().toString(16));
-            System.out.printf("Public Key (as ECPoint): %s\n", pubkey);
-            System.out.printf("Public Key (Compressed): %s\n", formatter.formatHex(compressed_pubkey.bytes()));
-            System.out.printf("Signature: %s\n", formatter.formatHex(serialized_signature.bytes()));
+            System.out.println("Is the signature valid? " + is_signature_valid);
+            System.out.println("Secret Key: " + privKey.getS().toString(16));
+            System.out.println("Public Key (as ECPoint): " + pubkey);
+            System.out.println("Public Key (Compressed): " + formatter.formatHex(compressed_pubkey.bytes()));
+            System.out.println("Signature: " + formatter.formatHex(serialized_signature.bytes()));
 
             /* It's best practice to try to clear secrets from memory after using them.
              * This is done because some bugs can allow an attacker to leak memory, for

--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Schnorr.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Schnorr.java
@@ -63,10 +63,10 @@ public class Schnorr {
 
             boolean is_signature_valid = secp.schnorrSigVerify(signature, msg_hash2, xOnly2).get();
 
-            System.out.printf("Is the signature valid? %s\n", is_signature_valid);
-            System.out.printf("Secret Key: %s\n", keyPair.getS().toString(16));
-            System.out.printf("Public Key (as ECPoint): %s\n", xOnly2);
-            System.out.printf("Signature: %s\n", formatter.formatHex(signature));
+            System.out.println("Is the signature valid? " + is_signature_valid);
+            System.out.println("Secret Key: " + keyPair.getS().toString(16));
+            System.out.println("Public Key (as ECPoint): " + xOnly2);
+            System.out.println("Signature: " + formatter.formatHex(signature));
 
             /* It's best practice to try to clear secrets from memory after using them.
              * This is done because some bugs can allow an attacker to leak memory, for


### PR DESCRIPTION
This is arguably only a minor improvement, but we should definitely move to `println`, because when https://openjdk.org/jeps/477 goes final we'll be able to remove the `System.out` qualifier.