### PR TITLE
secp-examples-kotlin: Move main() to top-level

### DIFF
--- a/secp-examples-kotlin/build.gradle
+++ b/secp-examples-kotlin/build.gradle
@@ -18,7 +18,7 @@ kotlin {
 }
 
 application {
-    mainClass = 'org.bitcoinj.secp.kotlin.examples.Schnorr'
+    mainClass = 'org.bitcoinj.secp.kotlin.examples.SchnorrKt'
 }
 
 def userHome = System.getProperty("user.home")
@@ -35,6 +35,6 @@ tasks.register('runEcdsa', JavaExec) {
     }
     systemProperty "java.library.path", javaLibraryPath
     classpath = sourceSets.main.runtimeClasspath
-    mainClass = 'org.bitcoinj.secp.kotlin.examples.Ecdsa'
+    mainClass = 'org.bitcoinj.secp.kotlin.examples.EcdsaKt'
     jvmArgs += '--enable-native-access=ALL-UNNAMED'
 }

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
@@ -21,78 +21,75 @@ import java.security.NoSuchAlgorithmException
 import java.util.*
 
 /**
- * Port of secp256k1 sample `ecdsa.c` to Java
+ * Port of secp256k1 sample `ecdsa.c` to Kotlin
  */
-object Ecdsa {
-    private val formatter: HexFormat = HexFormat.of()
+fun main() {
+    val formatter: HexFormat = HexFormat.of()
 
     /* Instead of signing the message directly, we must sign a 32-byte hash.
      * Here the message is "Hello, world!" and the hash function is SHA-256.
      * See https://bitcoin.stackexchange.com/questions/81115/if-someone-wanted-to-pretend-to-be-satoshi-by-posting-a-fake-signature-to-defrau/81116#81116
      */
-    private val msg_hash = hash("Hello, world!")
+    val msg_hash = hash("Hello, world!")
 
-    @JvmStatic
-    fun main(args: Array<String>) {
-        println("Running secp256k1-jdk Ecdsa example...")
-        Secp256k1.getByName("ffm").use { secp ->
-            /* === Key Generation === */
-            /* Return a non-zero, in-range private key */
-            val privKey = secp.ecPrivKeyCreate()
+    println("Running secp256k1-jdk Ecdsa example...")
+    Secp256k1.getByName("ffm").use { secp ->
+        /* === Key Generation === */
+        /* Return a non-zero, in-range private key */
+        val privKey = secp.ecPrivKeyCreate()
 
-            //P256k1PrivKey privKey = new BouncyPrivKey(BigInteger.ONE);
+        //P256k1PrivKey privKey = new BouncyPrivKey(BigInteger.ONE);
 
-            /* Public key creation using a valid context with a verified secret key should never fail */
-            val pubkey = secp.ecPubKeyCreate(privKey)
+        /* Public key creation using a valid context with a verified secret key should never fail */
+        val pubkey = secp.ecPubKeyCreate(privKey)
 
-            /* Serialize the pubkey in a compressed form(33 bytes). */
-            val compressed_pubkey = secp.ecPubKeySerialize(pubkey, 258 /* secp256k1_h.SECP256K1_EC_COMPRESSED() */)
+        /* Serialize the pubkey in a compressed form(33 bytes). */
+        val compressed_pubkey = secp.ecPubKeySerialize(pubkey, 258 /* secp256k1_h.SECP256K1_EC_COMPRESSED() */)
 
-            /* === Signing === */
+        /* === Signing === */
 
-            /* Generate an ECDSA signature using the RFC-6979 safe default nonce.
-             * Signing with a valid context, verified secret key and the default nonce function should never fail. */
-            val sig = secp.ecdsaSign(msg_hash, privKey).get()
+        /* Generate an ECDSA signature using the RFC-6979 safe default nonce.
+         * Signing with a valid context, verified secret key and the default nonce function should never fail. */
+        val sig = secp.ecdsaSign(msg_hash, privKey).get()
 
-            /* Serialize the signature in a compact form. Should always succeed according to
-             the documentation in secp256k1.h. */
-            val serialized_signature = secp.ecdsaSignatureSerializeCompact(sig).get()
+        /* Serialize the signature in a compact form. Should always succeed according to
+         the documentation in secp256k1.h. */
+        val serialized_signature = secp.ecdsaSignatureSerializeCompact(sig).get()
 
-            /* === Verification === */
+        /* === Verification === */
 
-            /* Deserialize the signature. This will return empty if the signature can't be parsed correctly. */
-            val sig2 = secp.ecdsaSignatureParseCompact(serialized_signature).get()
-            assert(sig.bytes().contentEquals(sig2.bytes()))
-            /* Deserialize the public key. This will return empty if the public key can't be parsed correctly. */
-            val pubkey2 = secp.ecPubKeyParse(compressed_pubkey).get()
-            assert(pubkey.w == pubkey2.w)
-            /* Verify a signature. This will return true if it's valid and false if it's not. */
-            val is_signature_valid = secp.ecdsaVerify(sig2, msg_hash, pubkey2).get()
+        /* Deserialize the signature. This will return empty if the signature can't be parsed correctly. */
+        val sig2 = secp.ecdsaSignatureParseCompact(serialized_signature).get()
+        assert(sig.bytes().contentEquals(sig2.bytes()))
+        /* Deserialize the public key. This will return empty if the public key can't be parsed correctly. */
+        val pubkey2 = secp.ecPubKeyParse(compressed_pubkey).get()
+        assert(pubkey.w == pubkey2.w)
+        /* Verify a signature. This will return true if it's valid and false if it's not. */
+        val is_signature_valid = secp.ecdsaVerify(sig2, msg_hash, pubkey2).get()
 
-            println("Is the signature valid? $is_signature_valid")
-            println("Secret Key: ${privKey.s.toString(16)}")
-            println("Public Key (as ECPoint): $pubkey")
-            println("Public Key (Compressed): ${formatter.formatHex(compressed_pubkey.bytes())}")
-            println("Signature: ${formatter.formatHex(serialized_signature.bytes())}")
+        println("Is the signature valid? $is_signature_valid")
+        println("Secret Key: ${privKey.s.toString(16)}")
+        println("Public Key (as ECPoint): $pubkey")
+        println("Public Key (Compressed): ${formatter.formatHex(compressed_pubkey.bytes())}")
+        println("Signature: ${formatter.formatHex(serialized_signature.bytes())}")
 
-            /* It's best practice to try to clear secrets from memory after using them.
-             * This is done because some bugs can allow an attacker to leak memory, for
-             * example through "out of bounds" array access (see Heartbleed), Or the OS
-             * swapping them to disk. Hence, we overwrite the secret key buffer with zeros.
-             */
-            privKey.destroy()
-        }
+        /* It's best practice to try to clear secrets from memory after using them.
+         * This is done because some bugs can allow an attacker to leak memory, for
+         * example through "out of bounds" array access (see Heartbleed), Or the OS
+         * swapping them to disk. Hence, we overwrite the secret key buffer with zeros.
+         */
+        privKey.destroy()
     }
+}
 
-    private fun hash(messageString: String): ByteArray {
-        val digest: MessageDigest
-        try {
-            digest = MessageDigest.getInstance("SHA-256")
-        } catch (e: NoSuchAlgorithmException) {
-            throw RuntimeException(e) // Can't happen.
-        }
-        val message = messageString.toByteArray()
-        digest.update(message, 0, message.size)
-        return digest.digest()
+private fun hash(messageString: String): ByteArray {
+    val digest: MessageDigest
+    try {
+        digest = MessageDigest.getInstance("SHA-256")
+    } catch (e: NoSuchAlgorithmException) {
+        throw RuntimeException(e) // Can't happen.
     }
+    val message = messageString.toByteArray()
+    digest.update(message, 0, message.size)
+    return digest.digest()
 }

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Schnorr.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Schnorr.kt
@@ -19,55 +19,50 @@ import org.bitcoinj.secp.api.P256K1XOnlyPubKey
 import org.bitcoinj.secp.api.Secp256k1
 import java.util.*
 
-/**
- *
- */
-object Schnorr {
-    private val formatter: HexFormat = HexFormat.of()
 
-    private const val msg = "Hello, world!"
-    private const val tag = "my_fancy_protocol"
+fun main() {
+    val formatter: HexFormat = HexFormat.of()
 
-    @JvmStatic
-    fun main(args: Array<String>) {
-        println("Running secp256k1-jdk Schnorr example...")
-        Secp256k1.getByName("ffm").use { secp ->
-            /* === Key Generation === */
-            /* Return a non-zero, in-range private key */
-            val keyPair = secp.ecKeyPairCreate()
+    val msg = "Hello, world!"
+    val tag = "my_fancy_protocol"
 
-            //P256K1KeyPair keyPair = secp.ecKeyPairCreate(new BouncyPrivKey(BigInteger.ONE));
+    println("Running secp256k1-jdk Schnorr example...")
+    Secp256k1.getByName("ffm").use { secp ->
+        /* === Key Generation === */
+        /* Return a non-zero, in-range private key */
+        val keyPair = secp.ecKeyPairCreate()
 
-            /* Public key creation using a valid context with a verified secret key should never fail */
-            val pubkey = secp.ecPubKeyCreate(keyPair)
+        //P256K1KeyPair keyPair = secp.ecKeyPairCreate(new BouncyPrivKey(BigInteger.ONE));
 
-            val xOnly = pubkey.xOnly
+        /* Public key creation using a valid context with a verified secret key should never fail */
+        val pubkey = secp.ecPubKeyCreate(keyPair)
 
-            val serializedXOnly = xOnly.getSerialized()
+        val xOnly = pubkey.xOnly
 
-            /* === Signing === */
-            val msg_hash = secp.taggedSha256(tag, msg)
+        val serializedXOnly = xOnly.getSerialized()
 
-            val signature = secp.schnorrSigSign32(msg_hash, keyPair)
+        /* === Signing === */
+        val msg_hash = secp.taggedSha256(tag, msg)
 
-            /* === Verification === */
-            val xOnly2 : P256K1XOnlyPubKey = P256K1XOnlyPubKey.parse(serializedXOnly).get()
+        val signature = secp.schnorrSigSign32(msg_hash, keyPair)
 
-            /* Compute the tagged hash on the received message using the same tag as the signer. */
-            val msg_hash2 = secp.taggedSha256(tag, msg)
+        /* === Verification === */
+        val xOnly2 : P256K1XOnlyPubKey = P256K1XOnlyPubKey.parse(serializedXOnly).get()
 
-            val is_signature_valid = secp.schnorrSigVerify(signature, msg_hash2, xOnly2).get()
+        /* Compute the tagged hash on the received message using the same tag as the signer. */
+        val msg_hash2 = secp.taggedSha256(tag, msg)
 
-            println("Is the signature valid? $is_signature_valid")
-            println("Secret Key: ${keyPair.s.toString(16)}")
-            println("Public Key (as ECPoint): $xOnly2")
-            println("Signature: ${formatter.formatHex(signature)}")
+        val is_signature_valid = secp.schnorrSigVerify(signature, msg_hash2, xOnly2).get()
 
-            /* It's best practice to try to clear secrets from memory after using them.
-             * This is done because some bugs can allow an attacker to leak memory, for
-             * example through "out of bounds" array access (see Heartbleed), Or the OS
-             * swapping them to disk. Hence, we overwrite the secret key buffer with zeros. */
-            keyPair.destroy()
-        }
+        println("Is the signature valid? $is_signature_valid")
+        println("Secret Key: ${keyPair.s.toString(16)}")
+        println("Public Key (as ECPoint): $xOnly2")
+        println("Signature: ${formatter.formatHex(signature)}")
+
+        /* It's best practice to try to clear secrets from memory after using them.
+         * This is done because some bugs can allow an attacker to leak memory, for
+         * example through "out of bounds" array access (see Heartbleed), Or the OS
+         * swapping them to disk. Hence, we overwrite the secret key buffer with zeros. */
+        keyPair.destroy()
     }
 }


### PR DESCRIPTION
We'll do this in Java too, once JEP 477, "Implicitly Declared Classes and Instance Main Methods" is out of preview.