### PR TITLE
Result: remove type reification in instanceof

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/api/Result.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/Result.java
@@ -65,9 +65,9 @@ public /* sealed */ interface Result<T> {
         return get("Error");
     }
     default T get(String message) {
-        if (this instanceof Ok<T>) {
+        if (this instanceof Ok) {
             return ((Ok<T>) this).result();
-        } else if (this instanceof Err<T>) {
+        } else if (this instanceof Err) {
            throw new IllegalStateException(message + ": " + ((Err<T>)this).code());
         } else {
             throw new IllegalStateException("Can't get here");


### PR DESCRIPTION
This was added in JDK 16, we want to support earlier JDKs.