### PR TITLE
build.gradle: remove sourceCompatibility/targetCompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,6 @@ subprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.toVersion("22")
-        targetCompatibility = JavaVersion.toVersion("22")
         toolchain {
             // `languageVersion` is used to configure the "Java Toolchain" used for the build. This includes `javac`,
             // `jlink`, and the `jpackage` tool.


### PR DESCRIPTION
We will never be compiling with JDK 8 (although we may end up _targeting_ Java 8)