### PR TITLE
api/module-info,ByteArray: stop leaking HEX_FORMAT

### DIFF
--- a/secp-api/src/main/java/module-info.java
+++ b/secp-api/src/main/java/module-info.java
@@ -18,7 +18,6 @@ module org.bitcoinj.secp.api {
     requires org.jspecify;
 
     exports org.bitcoinj.secp.api;
-    exports org.bitcoinj.secp.api.internal; /* TEMPORARY */
 
     uses org.bitcoinj.secp.api.Secp256k1Provider;
 }

--- a/secp-api/src/main/java/org/bitcoinj/secp/api/ByteArray.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/ByteArray.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
  * An effectively-immutable byte array.
  */
 public interface ByteArray extends Comparable<ByteArray> {
-    HexFormat HEX_FORMAT = new HexFormat();
 
     /**
      * @return the bytes as an array
@@ -35,7 +34,7 @@ public interface ByteArray extends Comparable<ByteArray> {
      * @return the bytes as a hex-formatted string
      */
     default String formatHex() {
-        return HEX_FORMAT.formatHex(bytes());
+        return toHexString(bytes());
     }
 
     /**
@@ -55,6 +54,16 @@ public interface ByteArray extends Comparable<ByteArray> {
      * @return hex-formatted String
      */
     static String toHexString(byte[] bytes) {
-        return HEX_FORMAT.formatHex(bytes);
+        return ByteArrayBase.HEX_FORMAT.formatHex(bytes);
+    }
+
+    /**
+     * Abstract Base Class for creating ByteArray Implementations
+     */
+    abstract class ByteArrayBase implements ByteArray {
+        private static final HexFormat HEX_FORMAT = new HexFormat();
+
+        @Override
+        public abstract byte[] bytes();
     }
 }

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/BouncyPubKey.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/BouncyPubKey.java
@@ -50,7 +50,7 @@ public class BouncyPubKey implements P256k1PubKey {
 
     @Override
     public String toString() {
-        return ByteArray.HEX_FORMAT.formatHex(bytes());
+        return ByteArray.toHexString(bytes());
     }
 
     @Override


### PR DESCRIPTION
Create nested ByteArrayBase abstract class.  (Will be flushed-out later with more methods) 

Move HEX_FORMAT inside ByteArrayBase so it can be `private`.

module-info: stop exporting o.b.s.api.internal

This is a cleanup follow-on to PR #85.
