### PR TITLE
gradle.yml: Simplify running of examples

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,5 @@ jobs:
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
         run: ./gradlew build
-      - name: Run Java Examples
-        run: ./gradlew secp-examples-java:run secp-examples-java:runEcdsa
-      - name: Run Kotlin Examples
-        run: ./gradlew secp-examples-kotlin:run secp-examples-kotlin:runEcdsa
+      - name: Run Java & Kotlin Examples
+        run: ./gradlew run runEcdsa


### PR DESCRIPTION
* Run Java & Kotlin examples with same gradlew command
* Use `run` and `runEcdsa` targets to be less verbose