### PR TITLE
GitHub gradle.yml workflow: use JDK 23

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         distribution: ['temurin']
       fail-fast: false
-    name: ${{ matrix.os }} JDK 22
+    name: ${{ matrix.os }} JDK 23
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -18,11 +18,9 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: ${{ matrix.distribution }}
-          # Setup JDK 21 & JDK 22 to make JDK 22 available to the Gradle Java Toolchains feature
           # When installing multiple JDKs, the last JDK installed is the default and will be used to run Gradle itself
           java-version: |
-            22
-            21
+            23
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
@@ -36,6 +34,6 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew -PjavaToolchainVersion=23 build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew run runEcdsa
+        run: ./gradlew -PjavaToolchainVersion=23 run runEcdsa

--- a/secp-examples-java/build.gradle
+++ b/secp-examples-java/build.gradle
@@ -38,7 +38,7 @@ run {
 
 tasks.register('runEcdsa', JavaExec) {
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(javaToolchainVersion)
     }
     systemProperty "java.library.path", javaLibraryPath
     classpath = sourceSets.main.runtimeClasspath

--- a/secp-examples-kotlin/build.gradle
+++ b/secp-examples-kotlin/build.gradle
@@ -14,7 +14,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 kotlin {
-    jvmToolchain(22)
+    jvmToolchain(javaToolchainVersion as int)
 }
 
 application {
@@ -31,7 +31,7 @@ run {
 
 tasks.register('runEcdsa', JavaExec) {
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(javaToolchainVersion)
     }
     systemProperty "java.library.path", javaLibraryPath
     classpath = sourceSets.main.runtimeClasspath


### PR DESCRIPTION
Our Gradle wrapper is already using Gradle 8.10, so JDK 23 is supported. 

Use `-PjavaToolchainVersion=23` on the Gradle command line in gradle.yml and leave the default value of javaToolchainVersion=22 (gradle.properties) for people using Nix or other environments that don't have JDK 23 available yet.

Update secp-examples-*/build.gradle to use javaToolchainVersion when configuring toolchains.