### PR TITLE
flake.{nix,lock}: Update to JDK23 (and temporarily un-include jextract)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722113426,
-        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -49,10 +49,11 @@
 #            ];
           inputsFrom = with pkgs ; [ secp256k1 ];
           packages = with pkgs ; [
-                jdk22                # JDK 22 will be in $JAVA_HOME (and in javaToolchains)
-                jextract             # jextract (Nix package) contains a jlinked executable and bundles its own JDK 22
-                (gradle.override {   # Gradle 8.x (Nix package) depends-on and directly uses JDK 21 to launch Gradle itself
-                    javaToolchains = [ jdk22 ];     # Put JDK 22 in Gradle's javaToolchain configuration
+                jdk23                # JDK 23 will be in $JAVA_HOME (and in javaToolchains)
+                # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
+                # jextract             # jextract (Nix package) contains a jlinked executable and bundles its own JDK
+                (gradle.override {   # Gradle 8.x (Nix package) depends-on and directly uses JDK XX to launch Gradle itself
+                    javaToolchains = [ jdk23 ];     # Put JDK 23 in Gradle's javaToolchain configuration
                 })
             ];
         };


### PR DESCRIPTION
NixPkgs has removed JDK 22 as "unsupported" and now provides jdk23. The jextract package has not been upgraded and is marked as `broken`.

Given that `jextract` is not needed to build `secp256k1-jdk` from source, it is commented out for now.
(jextract is included in the `nix develop` environment for updating the generated wrapper manually)

The flake.lock file is also updated to the latest hashes.