### PR TITLE
gradle.properties: javaToolchainVersion = 23

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew -PjavaToolchainVersion=23 build
+        run: ./gradlew build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew -PjavaToolchainVersion=23 run runEcdsa
+        run: ./gradlew run runEcdsa

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 secpVersion = 0.0.1
 
 # Major (whole number) version of JDK to use for javac, jlink, jpackage, etc.
-javaToolchainVersion = 22
+javaToolchainVersion = 23
 # Vendor for javaToolChain. (Should be indicator string from Gradle's KnownJvmVendor enum or empty string)
 # Official builds use 'Eclipse Adoptium'
 #javaToolchainVendor = Eclipse Adoptium
 javaToolchainVendor =
 
 # Where to look for JDKs (via environment variables)
-org.gradle.java.installations.fromEnv = JAVA_HOME, JDK22
+org.gradle.java.installations.fromEnv = JAVA_HOME, JDK23
 
 # Auto-detection can be disabled if you have multiple JDKs of the
 # same version installed and Gradle won't reliably select the version you actually want


### PR DESCRIPTION
This sets the default toolchain to JDK 23. This does not change the supported version of any of the outputs.

If for some reason you still need to build with JDK 22, you can use the `-PjavaToolchainVersion=22` option to Gradle.

GitHub actions gradle.yml is also updated to no longer use the -P option to override the toolchain version.