### PR TITLE
secp-examples-kotlin/build.gradle: target JVM_22

### DIFF
--- a/secp-examples-kotlin/build.gradle
+++ b/secp-examples-kotlin/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id "org.jetbrains.kotlin.jvm" version "2.0.21"
     id 'application'
@@ -15,6 +17,7 @@ tasks.withType(JavaCompile).configureEach {
 
 kotlin {
     jvmToolchain(javaToolchainVersion as int)
+    compilerOptions.jvmTarget = JvmTarget.JVM_22
 }
 
 application {


### PR DESCRIPTION
Set the target JVM version for the output JAR explicitly to JVM_22