### PR TITLE
flake.nix: use temurin-bin-23 instead of jdk23

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
                 # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
                 # jextract             # jextract (Nix package) contains a jlinked executable and bundles its own JDK
                 (gradle.override {   # Gradle 8.x (Nix package) depends-on and directly uses JDK XX to launch Gradle itself
-                    javaToolchains = [ jdk23 ];     # Put JDK 23 in Gradle's javaToolchain configuration
+                    javaToolchains = [ temurin-bin-23 ]; # Put JDK 23 in Gradle's javaToolchain configuration
                 })
             ];
         };


### PR DESCRIPTION
This is a workaround for Issue #93.  (But we should switch back to `jdk23` which is built from source, when it or gradle is fixed)

This is a child of PR #103  (We should update to latest Nixpkgs versions as that is what I have been testing with)
