### PR TITLE
gradle.yml: explicit os versions: ubuntu-24.04, macos-14

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-24.04, macOS-14]
         distribution: ['temurin']
       fail-fast: false
     name: ${{ matrix.os }} JDK 23


### PR DESCRIPTION
As of today, these are both the same as `-latest`, but this makes the CI build slightly more reproducible and prevents allows us to migrate to newer versions manually, rather than having GitHub do it for us.