### PR TITLE
maven-publish.gradle: fix 2 deprecation warnings

### DIFF
--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -13,8 +13,8 @@ subprojects { sub ->
             repositories {
                 def secpJdkGitLabProjectId = "55956336"
                 maven {
-                    url "https://gitlab.com/api/v4/projects/${secpJdkGitLabProjectId}/packages/maven"
-                    name "GitLab"
+                    url = "https://gitlab.com/api/v4/projects/${secpJdkGitLabProjectId}/packages/maven"
+                    name = "GitLab"
                     credentials(HttpHeaderCredentials) {
                         name = 'Private-Token'
                         value = project.findProperty("gitLabMavenToken")


### PR DESCRIPTION
The warnings were:

Space-assignment syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0.
Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: 
https://docs.gradle.org/8.12.1/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

With this fix there are currently no deprecation warnings.