### PR TITLE
GHA gradle.yml: add build_nix job

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,7 @@ name: Gradle Build
 on: [push, pull_request]
 
 jobs:
-  build:
+  build_gradle:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -32,3 +32,23 @@ jobs:
         run: ./gradlew build
       - name: Run Java & Kotlin Examples
         run: ./gradlew run runEcdsa
+
+
+  build_nix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-14]
+      fail-fast: false
+    name: ${{ matrix.os }} Nix
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install secp256k1 with Nix
+        run: nix profile install nixpkgs#secp256k1
+      - name: Build in Nix development shell
+        run: nix develop -c gradle build run runEcdsa


### PR DESCRIPTION
Add build_nix job to do a full build/run using:

nix develop -c gradle build run runEcdsa

This will verify that flake.nix and flake.lock are working correctly for a development shell. 

(Obviously we still need a real/full nix build)