### PR TITLE
GHA gradle-wapper-validation.yml: update to v3

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,5 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
-
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
Note that the wrapper migrated to a new repo.

See https://github.com/gradle/wrapper-validation-action/issues/198