### PR TITLE
GHA gradle.yml: build_gradle needs validate_gradle_wrapper

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: gradle/actions/wrapper-validation@v3
 
   build_gradle:
+    needs: validate_gradle_wrapper
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
This will prevent build_gradle from running if the wrapper is invalid.

~~This is a child of PR #124~~ PR #124 has been merged. 