### PR TITLE
GHA gradle.yml: Build with JDK 24

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-14]
         distribution: ['temurin']
       fail-fast: false
-    name: ${{ matrix.os }} JDK 23
+    name: ${{ matrix.os }} JDK 24 (via Gradle Java toolchains)
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -28,6 +28,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           # When installing multiple JDKs, the last JDK installed is the default and will be used to run Gradle itself
           java-version: |
+            24
             23
           cache: 'gradle'
       - name: Install Nix
@@ -37,9 +38,9 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew -PjavaToolchainVersion=24 build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew run runEcdsa
+        run: ./gradlew -PjavaToolchainVersion=24 run runEcdsa
 
 
   build_nix:

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ javaToolchainVersion = 23
 javaToolchainVendor =
 
 # Where to look for JDKs (via environment variables)
-org.gradle.java.installations.fromEnv = JAVA_HOME, JDK23
+org.gradle.java.installations.fromEnv = JAVA_HOME, JDK23, JDK24
 
 # Auto-detection can be disabled if you have multiple JDKs of the
 # same version installed and Gradle won't reliably select the version you actually want


### PR DESCRIPTION
secp-jdk is still built with JDK 23 by default. JVM requirements of JARs
is also unchanged. This commit just updates the GitHub Actions gradle
build to use JDK 24. The GitHub Actions Nix build continues to use
JDK 23.

GHA gradle.yml:
* Install both JDK 23 (to launch Gradle) and 24 (to compile Java)
* Override default and build with `-PjavaToolchainVersion=24`

gradle.properties:
* Add a `JDK24` environment variable as a place to search for JDKs

Builds will by default be with JDK23 (because of an unchanged property
in gradle.properties), but it can be overridden with:

`./gradlew -PjavaToolchainVersion=24 build`
