### PR TITLE
flake.nix: use JDK 23 to run devshell Gradle 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,25 +28,7 @@
         inherit (pkgs) stdenv;
       in {
         # define default devshell
-#        devShells.default = inputs'.devshell.legacyPackages.mkShell {
         devShells.default = pkgs.mkShell {
-          # setup some environment variables
-#          env = with lib;
-#            mkMerge [
-#              [
-#                # Configure nix to use nixpkgs
-#                {
-#                  name = "NIX_PATH";
-#                  value = "nixpkgs=${toString pkgs.path}";
-#                }
-#              ]
-#              (mkIf stdenv.isLinux [
-#                {
-#                  name = "JAVA_HOME";
-#                  eval = "$DEVSHELL_DIR/lib/openjdk";
-#                }
-#              ])
-#            ];
           inputsFrom = with pkgs ; [ secp256k1 ];
           packages = with pkgs ; [
                 jdk23                # JDK 23 will be in $JAVA_HOME (and in javaToolchains)

--- a/flake.nix
+++ b/flake.nix
@@ -31,11 +31,11 @@
         devShells.default = pkgs.mkShell {
           inputsFrom = with pkgs ; [ secp256k1 ];
           packages = with pkgs ; [
-                jdk23                # JDK 23 will be in $JAVA_HOME (and in javaToolchains)
+                jdk23                      # JDK 23 will be in PATH
                 # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
-                # jextract             # jextract (Nix package) contains a jlinked executable and bundles its own JDK
-                (gradle.override {   # Gradle 8.x (Nix package) depends-on and directly uses JDK XX to launch Gradle itself
-                    javaToolchains = [ temurin-bin-23 ]; # Put JDK 23 in Gradle's javaToolchain configuration
+                # jextract                 # jextract (Nix package) contains a jlinked executable and bundles its own JDK
+                (gradle.override {         # Gradle 8.x (Nix package) runs using an internally-linked JDK
+                    java = jdk23;          # Run Gradle with this JDK
                 })
             ];
         };


### PR DESCRIPTION
This simplifies the configuration and reduces the number of JDKs that must be installed from 3 to 1.

There are two commits. The first one just removes some obsolete commented-out lines, the second makes the JDK change.