### PR TITLE
.gitlab-ci.yml: add a Sid (aka Forky) build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,9 +17,23 @@ nixos-devshell:
       - /nix/store
       - ~/.gradle/
 
-# Build on Trixie using Debian's OpenJDK 23, Gradle via the Wrapper and secp256k1 installed via nix profile install`.
+# Build on Trixie using Debian's OpenJDK 23, Gradle via the Wrapper and secp256k1 installed via `nix profile install`.
+# When Trixie is finalized, JDK 23 will probably be dropped, and we will need to use Nix to install a JDK.
 trixie-gradlew:
   image: debian:trixie-slim
+  before_script:
+    - apt-get update
+    - apt-get -y install openjdk-23-jdk-headless nix-setup-systemd
+    - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+    - nix profile install nixpkgs#secp256k1
+  script:
+    - ./gradlew build run runEcdsa
+
+# Build on Sid (Forky) using Debian's OpenJDK 23, Gradle via the Wrapper and secp256k1 installed via `nix profile install`.
+# Sid/Forky should eventually have an LTS OpenJDK 25 which is our target version for a production-quality release of
+# secp256k1-jdk. If we're lucky it might even get a Debian Gradle we can use. If so, we can make a Forky build that doesn't need Nix.
+forky-gradlew:
+  image: debian:sid-slim
   before_script:
     - apt-get update
     - apt-get -y install openjdk-23-jdk-headless nix-setup-systemd


### PR DESCRIPTION
This adds a sid/forky job to `.gitlab-ci.yml`. Other than using the `sid-slim` rather than `trixie-slim` image, it is currently the same as the Trixie job, but they will diverge over time as indicated in the comments.

~~This is a child or PR #132. The actual changes are in: ea7316f652dda80cd57b080071c33cdb438e29c3~~ Rebased