### PR TITLE
secp-api/secp-bouncy: backport to Java 8

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew -PapiModuleJavaCompatibility=8 build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew run runEcdsa
+        run: ./gradlew -PapiModuleJavaCompatibility=8 run runEcdsa
 
 
   build_nix:
@@ -59,4 +59,4 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build in Nix development shell
-        run: nix develop -c gradle build run runEcdsa
+        run: nix develop -c gradle -PapiModuleJavaCompatibility=8 build run runEcdsa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ nixos-devshell:
     - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
     - nix profile install nixpkgs#secp256k1
   script:
-    - nix develop .#minimum -c gradle build run runEcdsa
+    - nix develop .#minimum -c gradle -PapiModuleJavaCompatibility=8 build run runEcdsa
   cache:
     key: "${CI_COMMIT_REF_SLUG}"
     paths:
@@ -26,4 +26,4 @@ trixie-gradlew:
     - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
     - nix profile install nixpkgs#secp256k1
   script:
-    - ./gradlew build run runEcdsa
+    - ./gradlew -PapiModuleJavaCompatibility=8 build run runEcdsa

--- a/secp-api/build.gradle
+++ b/secp-api/build.gradle
@@ -1,12 +1,20 @@
 plugins {
     id 'java-library'
+    id 'org.beryx.jar' version '2.0.0'
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.release = 9
+    // IDEs and other tools will see `9` by default, but CI and release builds
+    // will set `-PapiModuleJavaCompatibility=8` to generate a Java 8 JAR
+    // and the `org.beryx.jar` plugin will put `module-info.jar` in the Java 8 JAR.
+    options.release = (findProperty('apiModuleJavaCompatibility') ?: 9) as int
 }
 
 ext.moduleName = 'org.bitcoinj.secp.api'
+
+moduleConfig {
+    version = project.version
+}
 
 dependencies {
     api("org.jspecify:jspecify:1.0.0")

--- a/secp-api/src/main/java/org/bitcoinj/secp/api/Secp256k1Provider.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/Secp256k1Provider.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
 
 /**
  *
@@ -65,8 +66,7 @@ public interface Secp256k1Provider {
      */
     static Optional<Secp256k1Provider> findFirst(Predicate<Secp256k1Provider> filter) {
         ServiceLoader<Secp256k1Provider> loader = ServiceLoader.load(Secp256k1Provider.class);
-        return loader.stream()
-                .map(ServiceLoader.Provider::get)
+        return StreamSupport.stream(loader.spliterator(), false)
                 .filter(filter)
                 .findFirst();
     }
@@ -76,7 +76,7 @@ public interface Secp256k1Provider {
      * @param provider a candidate provider
      * @return true if it should be "found"
      */
-    private static boolean defaultFilter(Secp256k1Provider provider) {
+    /* private */ static boolean defaultFilter(Secp256k1Provider provider) {
         return provider.name().equals("ffm");
     }
 }

--- a/secp-bouncy/build.gradle
+++ b/secp-bouncy/build.gradle
@@ -1,12 +1,20 @@
 plugins {
     id 'java-library'
+    id 'org.beryx.jar' version '2.0.0'
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.release = 9
+    // IDEs and other tools will see `9` by default, but CI and release builds
+    // will set `-PapiModuleJavaCompatibility=8` to generate a Java 8 JAR
+    // and the `org.beryx.jar` plugin will put `module-info.jar` in the Java 8 JAR.
+    options.release = (findProperty('apiModuleJavaCompatibility') ?: 9) as int
 }
 
 ext.moduleName = 'org.bitcoinj.secp.bouncy'
+
+moduleConfig {
+    version = project.version
+}
 
 dependencies {
     api project(':secp-api')


### PR DESCRIPTION
This PR means that released jars for the API and the Bouncy Castle implementation will be Java 8-compatible, but will still have `module-info` records in them. The `secp-ffm` module will remain at JDK 23+.

* IDEs will see modules as Java 9
* apiModuleJavaCompatibility property is used with org.beryx.jar Gradle plugin to create Java 8 JARs with module-info on official builds
* Remove all usages of Java 9 API

Developers of secp-jdk using IDEs will need to be aware that the actual requirements are Java 8 API. But mistakes will be caught by CI.