### PR TITLE
Gradle: revert use of org.beryx.jar plugin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew -PapiModuleJavaCompatibility=8 build
+        run: ./gradlew build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew -PapiModuleJavaCompatibility=8 run runEcdsa
+        run: ./gradlew run runEcdsa
 
 
   build_nix:
@@ -59,4 +59,4 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build in Nix development shell
-        run: nix develop -c gradle -PapiModuleJavaCompatibility=8 build run runEcdsa
+        run: nix develop -c gradle build run runEcdsa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ nixos-devshell:
     - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
     - nix profile install nixpkgs#secp256k1
   script:
-    - nix develop .#minimum -c gradle -PapiModuleJavaCompatibility=8 build run runEcdsa
+    - nix develop .#minimum -c gradle build run runEcdsa
   cache:
     key: "${CI_COMMIT_REF_SLUG}"
     paths:
@@ -26,4 +26,4 @@ trixie-gradlew:
     - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
     - nix profile install nixpkgs#secp256k1
   script:
-    - ./gradlew -PapiModuleJavaCompatibility=8 build run runEcdsa
+    - ./gradlew build run runEcdsa

--- a/secp-api/build.gradle
+++ b/secp-api/build.gradle
@@ -1,20 +1,12 @@
 plugins {
     id 'java-library'
-    id 'org.beryx.jar' version '2.0.0'
 }
 
 tasks.withType(JavaCompile).configureEach {
-    // IDEs and other tools will see `9` by default, but CI and release builds
-    // will set `-PapiModuleJavaCompatibility=8` to generate a Java 8 JAR
-    // and the `org.beryx.jar` plugin will put `module-info.jar` in the Java 8 JAR.
-    options.release = (findProperty('apiModuleJavaCompatibility') ?: 9) as int
+    options.release = 9
 }
 
 ext.moduleName = 'org.bitcoinj.secp.api'
-
-moduleConfig {
-    version = project.version
-}
 
 dependencies {
     api("org.jspecify:jspecify:1.0.0")

--- a/secp-bouncy/build.gradle
+++ b/secp-bouncy/build.gradle
@@ -1,20 +1,12 @@
 plugins {
     id 'java-library'
-    id 'org.beryx.jar' version '2.0.0'
 }
 
 tasks.withType(JavaCompile).configureEach {
-    // IDEs and other tools will see `9` by default, but CI and release builds
-    // will set `-PapiModuleJavaCompatibility=8` to generate a Java 8 JAR
-    // and the `org.beryx.jar` plugin will put `module-info.jar` in the Java 8 JAR.
-    options.release = (findProperty('apiModuleJavaCompatibility') ?: 9) as int
+    options.release = 9
 }
 
 ext.moduleName = 'org.bitcoinj.secp.bouncy'
-
-moduleConfig {
-    version = project.version
-}
 
 dependencies {
     api project(':secp-api')


### PR DESCRIPTION
This reverts most of PR #140 / commit 2afefa09aac04af6b921fc8beeb07eeeffb535ce

The changes to Secp256k1Provider.java which removed use of Java 9+ features and APIs will remain, but the changes to the Gradle files to use the org.beryx.jar plugin and the changes to configure it during CI are reverted.

We still would like to be able to produce Java 8-compatible JARs for both secp-api and secp-bouncy, but we will take a fresh look at the best way to do so.