### PR TITLE
P256k1PubKey, BouncyPubKey: change primary encoding format to "Compressed SEC"

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PubKey.java
@@ -40,14 +40,7 @@ public interface P256k1PubKey extends ECPublicKey {
      */
     @Override
     default byte[] getEncoded() {
-        ECPoint point = getW();
-        byte[] x = integerTo32Bytes(point.getAffineX());
-        byte[] y = integerTo32Bytes(point.getAffineY());
-        byte[] encoded = new byte[65];
-        encoded[0] = 0x04;
-        System.arraycopy(x, 0, encoded, 1, 32);
-        System.arraycopy(y, 0, encoded, 33, 32);
-        return encoded;
+        return getUncompressed();
     }
 
     default byte[] getSerialized(boolean compressed) {
@@ -68,6 +61,17 @@ public interface P256k1PubKey extends ECPublicKey {
                 1,
                 32);
         return compressed;
+    }
+
+    default byte[] getUncompressed() {
+        ECPoint point = getW();
+        byte[] x = integerTo32Bytes(point.getAffineX());
+        byte[] y = integerTo32Bytes(point.getAffineY());
+        byte[] encoded = new byte[65];
+        encoded[0] = 0x04;
+        System.arraycopy(x, 0, encoded, 1, 32);
+        System.arraycopy(y, 0, encoded, 33, 32);
+        return encoded;
     }
 
     default P256K1XOnlyPubKey getXOnly() {

--- a/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PubKey.java
@@ -31,22 +31,22 @@ public interface P256k1PubKey extends ECPublicKey {
 
     @Override
     default String getFormat() {
-        return "Uncompressed SEC";
+        return "Compressed SEC";
     }
 
     /**
-     * Return key in primary encoded format (uncompressed for now)
-     * @return public key in uncompressed format
+     * Return key in primary encoded format (compressed)
+     * @return public key in compressed format
      */
     @Override
     default byte[] getEncoded() {
-        return getUncompressed();
+        return getCompressed();
     }
 
     default byte[] getSerialized(boolean compressed) {
         return compressed
                 ? getCompressed()
-                : getEncoded();
+                : getUncompressed();
     }
 
     default byte[] getCompressed() {

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/BouncyPubKey.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/BouncyPubKey.java
@@ -44,7 +44,7 @@ public class BouncyPubKey implements P256k1PubKey {
 
     @Override
     public byte[] getEncoded() {
-        return point.getEncoded(false);  // This has a prefix byte
+        return point.getEncoded(true);  // This has a prefix byte, default encoding is compressed
     }
 
     @Override


### PR DESCRIPTION
Have `getEncoded()` default to the preferred, more compact format.
