### PR TITLE
P256k1PubKey: rename getEncoded(boolean) from getSerialized(boolean) 

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PubKey.java
@@ -43,7 +43,12 @@ public interface P256k1PubKey extends ECPublicKey {
         return getCompressed();
     }
 
-    default byte[] getSerialized(boolean compressed) {
+    /**
+     * Return encoded key in either compressed or uncompressed SEC format.
+     * @param compressed Use compressed variant of format
+     * @return public key in SEC format
+     */
+    default byte[] getEncoded(boolean compressed) {
         return compressed
                 ? getCompressed()
                 : getUncompressed();

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -230,7 +230,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
             case 258 -> true;         // SECP256K1_EC_COMPRESSED())
             default -> throw new IllegalArgumentException();
         };
-        return new CompressedPubKeyPojo(pubKey.getSerialized(compressed));
+        return new CompressedPubKeyPojo(pubKey.getEncoded(compressed));
     }
 
     /* package */ static MemorySegment pubKeySerializeSegment(MemorySegment pubKeySegment, int flags) {


### PR DESCRIPTION
It should have the same method name as the standard `getEncoded()`.

~~This is a child of PR #150.~~

