### PR TITLE
secp-api module: add some top-level JavaDoc

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/api/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/Secp256k1.java
@@ -18,13 +18,32 @@ package org.bitcoinj.secp.api;
 import java.io.Closeable;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECFieldFp;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
 
 /**
- *
+ * A Java interface for <i>Elliptic Curve Cryptography</i> using the <a href="https://www.secg.org">SECG</a> curve
+ * <a href="https://en.bitcoin.it/wiki/Secp256k1">secp256k1</a>.
+ * <p>
+ * The API is based on the C-language API of <a href="https://github.com/bitcoin-core/secp256k1">libsecp256k1</a>, but
+ * is here adapted to modern, idiomatic, functional-style Java and use Elliptic Curve <i>types</i> from the Java Class Library,
+ * such as {@link ECPublicKey} via the specialized {@link P256k1PubKey} subclass.
+ * <p>
+ * Two implementations are being developed.
+ * <ul>
+ *     <li>
+ *      Module {@code org.bitcoinj.secp.ffm}: Using a
+ *      <a href="https://openjdk.org/jeps/454">Java Foreign Function and Memory API</a> interface to the
+ *      <a href="https://github.com/bitcoin-core/secp256k1">secp256k1</a> library.
+ *     </li>
+ *     <li>
+ *      Module {@code org.bitcoinj.secp.bouncy}: Using the <a href="https://www.bouncycastle.org">Bouncy Castle</a>
+ *      Java library.
+ *     </li>
+ * </ul>
  */
 public interface Secp256k1 extends Closeable {
 

--- a/secp-api/src/main/java/org/bitcoinj/secp/api/internal/package-info.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/internal/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023-2024 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal helper classes -- not for public use. These classes will not be exported by the {@link org.bitcoinj.secp.api} module
+ * and should not be used by non-modular applications.
+ */
+package org.bitcoinj.secp.api.internal;

--- a/secp-api/src/main/java/org/bitcoinj/secp/api/package-info.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/package-info.java
@@ -15,19 +15,12 @@
  */
 
 /**
- * API definition module for <a href="https://github.com/bitcoinj/secp256k1-jdk">secp256k1-jdk</a>, a Java library providing
+ * Main API package for the {@code org.bitcoinj.secp.api} module and JAR. Part of
+ * <a href="https://github.com/bitcoinj/secp256k1-jdk">secp256k1-jdk</a>, a Java library providing
  * <i>Elliptic Curve Cryptography</i> functions using the <a href="https://www.secg.org">SECG</a> curve
  * <a href="https://en.bitcoin.it/wiki/Secp256k1">secp256k1</a>.
  * It provides both ECDSA and Schnorr message-signing functions.
  * <p>
- * For more information see the package {@link org.bitcoinj.secp.api} or the main interface
- * {@link org.bitcoinj.secp.api.Secp256k1}.
+ * The main interface is defined in {@link org.bitcoinj.secp.api.Secp256k1}.
  */
-@org.jspecify.annotations.NullMarked
-module org.bitcoinj.secp.api {
-    requires org.jspecify;
-
-    exports org.bitcoinj.secp.api;
-
-    uses org.bitcoinj.secp.api.Secp256k1Provider;
-}
+package org.bitcoinj.secp.api;


### PR DESCRIPTION
* Add JavaDoc to module-info.java, this will not be available if we downgrade to Java 8.
* Add JavaDoc to main package-info.java
* Add package-info to `internal` package
* Add JavaDoc to main interface `Secp256k1`