### PR TITLE
P256k1PrivKey: add nested P256K1PrivKeyDefault implementation

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PrivKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PrivKey.java
@@ -15,9 +15,14 @@
  */
 package org.bitcoinj.secp.api;
 
+import org.jspecify.annotations.Nullable;
+
 import java.math.BigInteger;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.ECParameterSpec;
+import java.util.Arrays;
+
+import static org.bitcoinj.secp.api.P256k1PubKey.integerTo32Bytes;
 
 /**
  *  Verified private secret key
@@ -53,8 +58,69 @@ public interface P256k1PrivKey extends ECPrivateKey {
     }
 
     /**
+     * Construct a private key from an integer
+     * @param p Must be a member of the Secp256k1 field
+     * @return private key
+     */
+    static P256k1PrivKey of(BigInteger p) {
+        return new P256k1PrivKeyDefault(p);
+    }
+
+    /**
      * Destroy must be implemented and must not throw (checked) exceptions
      */
     @Override
     void destroy();
+
+    class P256k1PrivKeyDefault implements P256k1PrivKey {
+        /** private key or null if key was destroyed */
+        private byte @Nullable [] privKeyBytes;
+
+        /**
+         * Caller is responsible to defensively copy byte[]. This is to avoid
+         * a redundant copy. Exclusive ownership must be passed to this instance.
+         * @param bytes (will not be defensively copied)
+         */
+        protected P256k1PrivKeyDefault(byte[] bytes) {
+            // TODO: Range validation?
+            privKeyBytes = bytes;
+        }
+
+        private P256k1PrivKeyDefault(BigInteger privKey) {
+            // TODO: Valid integer is valid for field
+            this.privKeyBytes = integerTo32Bytes(privKey);
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            if (privKeyBytes == null) throwKeyDestroyed();
+            byte[] copy = new byte[privKeyBytes.length];
+            System.arraycopy(privKeyBytes, 0, copy, 0, privKeyBytes.length);
+            return copy;
+        }
+
+        @Override
+        public BigInteger getS() {
+            if (privKeyBytes == null) throwKeyDestroyed();
+            return ByteArray.toInteger(getEncoded());
+        }
+
+        @Override
+        public void destroy() {
+            // TODO: Make sure the zeroing is not optimized out by the compiler or JIT
+            if (privKeyBytes != null) {
+                Arrays.fill( privKeyBytes, (byte) 0x00 );
+                privKeyBytes = null;
+            }
+        }
+
+        @Override
+        public boolean isDestroyed() {
+            return privKeyBytes == null;
+        }
+
+        private void throwKeyDestroyed() {
+            throw new IllegalStateException("Private Key has been destroyed");
+        }
+    }
 }

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/PrivKeyPojo.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/PrivKeyPojo.java
@@ -16,59 +16,25 @@
 package org.bitcoinj.secp.ffm;
 
 import org.bitcoinj.secp.api.P256k1PrivKey;
-import org.jspecify.annotations.Nullable;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.math.BigInteger;
-import java.util.Arrays;
 
 /**
  * TODO: Verify validity at creation time
  */
-public class PrivKeyPojo implements P256k1PrivKey {
-
-    /** private key or null if key was destroyed */
-    private byte @Nullable [] privKeyBytes;
-
+public class PrivKeyPojo extends P256k1PrivKey.P256k1PrivKeyDefault {
     /**
      * Package private to ensure it is only created from a valid private key
-     * @param privKey
+     * @param privKey memory-segment with a libsecp256k1 private key
      */
     PrivKeyPojo(MemorySegment privKey) {
         // Make defensive copy, so we are effectively immutable
-        privKeyBytes = privKey.toArray(ValueLayout.JAVA_BYTE);
+        super(privKey.toArray(ValueLayout.JAVA_BYTE));
     }
 
     PrivKeyPojo(byte[] bytes) {
         // Make defensive copy, so we are effectively immutable
-        privKeyBytes = bytes.clone();
-    }
-
-    @Override
-    public byte[] getEncoded() {
-        if (privKeyBytes == null) throw new IllegalStateException("Private Key has been destroyed");
-        byte[] copy = new byte[privKeyBytes.length];
-        System.arraycopy(privKeyBytes, 0, copy, 0, privKeyBytes.length);
-        return copy;
-    }
-
-    public BigInteger integer() {
-        if (privKeyBytes == null) throw new IllegalStateException("Private Key has been destroyed");
-        return new BigInteger(1, privKeyBytes);
-    }
-
-    @Override
-    public void destroy() {
-        // TODO: Make sure the zeroing is not optimized out by the compiler or JIT
-        if (privKeyBytes != null) {
-            Arrays.fill( privKeyBytes, (byte) 0x00 );
-            privKeyBytes = null;
-        }
-    }
-
-    @Override
-    public boolean isDestroyed() {
-        return privKeyBytes == null;
+        super(bytes.clone());
     }
 }


### PR DESCRIPTION
* Migrate most of -ffm's PrivKeyPojo class into P256k1PrivKey.P256K1PrivKeyDefault
* Have PrivKeyPojo extend P256k1PrivKey.P256K1PrivKeyDefault (for MemorySegment stuff)
* Add `P256k1PrivKey.of(BigInteger)` convenience factory method