### PR TITLE
tests: use P256k1PrivKey.of(BigInteger) in place of BouncyPrivKey

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PrivKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/P256k1PrivKey.java
@@ -15,9 +15,14 @@
  */
 package org.bitcoinj.secp.api;
 
+import org.jspecify.annotations.Nullable;
+
 import java.math.BigInteger;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.ECParameterSpec;
+import java.util.Arrays;
+
+import static org.bitcoinj.secp.api.P256k1PubKey.integerTo32Bytes;
 
 /**
  *  Verified private secret key
@@ -53,8 +58,69 @@ public interface P256k1PrivKey extends ECPrivateKey {
     }
 
     /**
+     * Construct a private key from an integer
+     * @param p Must be a member of the Secp256k1 field
+     * @return private key
+     */
+    static P256k1PrivKey of(BigInteger p) {
+        return new P256k1PrivKeyDefault(p);
+    }
+
+    /**
      * Destroy must be implemented and must not throw (checked) exceptions
      */
     @Override
     void destroy();
+
+    class P256k1PrivKeyDefault implements P256k1PrivKey {
+        /** private key or null if key was destroyed */
+        private byte @Nullable [] privKeyBytes;
+
+        /**
+         * Caller is responsible to defensively copy byte[]. This is to avoid
+         * a redundant copy. Exclusive ownership must be passed to this instance.
+         * @param bytes (will not be defensively copied)
+         */
+        protected P256k1PrivKeyDefault(byte[] bytes) {
+            // TODO: Range validation?
+            privKeyBytes = bytes;
+        }
+
+        private P256k1PrivKeyDefault(BigInteger privKey) {
+            // TODO: Valid integer is valid for field
+            this.privKeyBytes = integerTo32Bytes(privKey);
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            if (privKeyBytes == null) throwKeyDestroyed();
+            byte[] copy = new byte[privKeyBytes.length];
+            System.arraycopy(privKeyBytes, 0, copy, 0, privKeyBytes.length);
+            return copy;
+        }
+
+        @Override
+        public BigInteger getS() {
+            if (privKeyBytes == null) throwKeyDestroyed();
+            return ByteArray.toInteger(getEncoded());
+        }
+
+        @Override
+        public void destroy() {
+            // TODO: Make sure the zeroing is not optimized out by the compiler or JIT
+            if (privKeyBytes != null) {
+                Arrays.fill( privKeyBytes, (byte) 0x00 );
+                privKeyBytes = null;
+            }
+        }
+
+        @Override
+        public boolean isDestroyed() {
+            return privKeyBytes == null;
+        }
+
+        private void throwKeyDestroyed() {
+            throw new IllegalStateException("Private Key has been destroyed");
+        }
+    }
 }

--- a/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
+++ b/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
@@ -22,10 +22,10 @@ import org.bitcoinj.base.SegwitAddress;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.secp.api.P256K1KeyPair;
 import org.bitcoinj.secp.api.P256K1XOnlyPubKey;
+import org.bitcoinj.secp.api.P256k1PrivKey;
 import org.bitcoinj.secp.api.P256k1PubKey;
 import org.bitcoinj.secp.api.Secp256k1;
 import org.bitcoinj.secp.bouncy.Bouncy256k1;
-import org.bitcoinj.secp.bouncy.BouncyPrivKey;
 import org.bitcoinj.secp.bouncy.BouncyPubKey;
 import org.bitcoinj.secp.ffm.PubKeyPojo;
 import org.junit.jupiter.api.Assertions;
@@ -51,7 +51,7 @@ public class AddressTest {
     void createAddressTest(BigInteger key, String address) throws Exception {
         Address tapRootAddress;
         try (Secp256k1 secp = Secp256k1.get()) {
-            P256K1KeyPair keyPair = secp.ecKeyPairCreate(new BouncyPrivKey(key));
+            P256K1KeyPair keyPair = secp.ecKeyPairCreate(P256k1PrivKey.of(key));
             WitnessMaker maker = new WitnessMaker(secp);
 //            P256K1XOnlyPubKey xOnlyKey = keyPair.getPublic().getXOnly();
 //            BigInteger tweakInt = calcTweak(xOnlyKey);
@@ -70,7 +70,7 @@ public class AddressTest {
     void createAddressTestBouncy(BigInteger key, String address) throws Exception {
         Address tapRootAddress;
         try (Secp256k1 secp = new Bouncy256k1()) {
-            P256K1KeyPair keyPair = secp.ecKeyPairCreate(new BouncyPrivKey(key));
+            P256K1KeyPair keyPair = secp.ecKeyPairCreate(P256k1PrivKey.of(key));
             WitnessMaker maker = new WitnessMaker(secp);
 //            P256K1XOnlyPubKey xOnlyKey = keyPair.getPublic().getXOnly();
 //            BigInteger tweakInt = calcTweak(xOnlyKey);

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/PrivKeyPojo.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/PrivKeyPojo.java
@@ -16,59 +16,25 @@
 package org.bitcoinj.secp.ffm;
 
 import org.bitcoinj.secp.api.P256k1PrivKey;
-import org.jspecify.annotations.Nullable;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.math.BigInteger;
-import java.util.Arrays;
 
 /**
  * TODO: Verify validity at creation time
  */
-public class PrivKeyPojo implements P256k1PrivKey {
-
-    /** private key or null if key was destroyed */
-    private byte @Nullable [] privKeyBytes;
-
+public class PrivKeyPojo extends P256k1PrivKey.P256k1PrivKeyDefault {
     /**
      * Package private to ensure it is only created from a valid private key
-     * @param privKey
+     * @param privKey memory-segment with a libsecp256k1 private key
      */
     PrivKeyPojo(MemorySegment privKey) {
         // Make defensive copy, so we are effectively immutable
-        privKeyBytes = privKey.toArray(ValueLayout.JAVA_BYTE);
+        super(privKey.toArray(ValueLayout.JAVA_BYTE));
     }
 
     PrivKeyPojo(byte[] bytes) {
         // Make defensive copy, so we are effectively immutable
-        privKeyBytes = bytes.clone();
-    }
-
-    @Override
-    public byte[] getEncoded() {
-        if (privKeyBytes == null) throw new IllegalStateException("Private Key has been destroyed");
-        byte[] copy = new byte[privKeyBytes.length];
-        System.arraycopy(privKeyBytes, 0, copy, 0, privKeyBytes.length);
-        return copy;
-    }
-
-    public BigInteger integer() {
-        if (privKeyBytes == null) throw new IllegalStateException("Private Key has been destroyed");
-        return new BigInteger(1, privKeyBytes);
-    }
-
-    @Override
-    public void destroy() {
-        // TODO: Make sure the zeroing is not optimized out by the compiler or JIT
-        if (privKeyBytes != null) {
-            Arrays.fill( privKeyBytes, (byte) 0x00 );
-            privKeyBytes = null;
-        }
-    }
-
-    @Override
-    public boolean isDestroyed() {
-        return privKeyBytes == null;
+        super(bytes.clone());
     }
 }

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/Bouncy256k1Test.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/Bouncy256k1Test.java
@@ -16,8 +16,8 @@
 package org.bitcoinj.secp.integration;
 
 import org.bitcoinj.secp.api.P256k1PubKey;
+import org.bitcoinj.secp.api.P256k1PrivKey;
 import org.bitcoinj.secp.bouncy.Bouncy256k1;
-import org.bitcoinj.secp.bouncy.BouncyPrivKey;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +30,7 @@ public class Bouncy256k1Test {
     @Test
     void pubKeyAdditionTestTwo() {
         try (Bouncy256k1 secp = new Bouncy256k1()) {
-            P256k1PubKey pubKey = secp.ecKeyPairCreate(new BouncyPrivKey(BigInteger.ONE)).getPublic();
+            P256k1PubKey pubKey = secp.ecKeyPairCreate(P256k1PrivKey.of(BigInteger.ONE)).getPublic();
             P256k1PubKey added = secp.ecPubKeyCombine(pubKey, pubKey);
             P256k1PubKey multiplied = secp.ecPubKeyTweakMul(pubKey, BigInteger.valueOf(2));
             Assertions.assertEquals(added.getW(), multiplied.getW());

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/CurveTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/CurveTest.java
@@ -19,7 +19,6 @@ import org.bitcoinj.secp.api.P256k1PrivKey;
 import org.bitcoinj.secp.api.P256k1PubKey;
 import org.bitcoinj.secp.api.Secp256k1;
 import org.bitcoinj.secp.bouncy.Bouncy256k1;
-import org.bitcoinj.secp.bouncy.BouncyPrivKey;
 import org.bitcoinj.secp.ffm.Secp256k1Foreign;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,7 @@ public class CurveTest {
     @Test
     void pubKeyCalc() {
         try (var secp = new Secp256k1Foreign(); var bouncy = new Bouncy256k1()) {
-            P256k1PrivKey privkey = new BouncyPrivKey(BigInteger.ONE);
+            P256k1PrivKey privkey = P256k1PrivKey.of(BigInteger.ONE);
 
             // Create pubkeys with both implementations
             P256k1PubKey pubkey_secp = secp.ecPubKeyCreate(privkey);

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/PrivKeyDataTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/PrivKeyDataTest.java
@@ -16,7 +16,6 @@
 package org.bitcoinj.secp.integration;
 
 import org.bitcoinj.secp.api.P256k1PrivKey;
-import org.bitcoinj.secp.bouncy.BouncyPrivKey;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import java.math.BigInteger;
 public class PrivKeyDataTest {
     @Test
     void testBouncyPriv() {
-        P256k1PrivKey priv = new BouncyPrivKey(BigInteger.ONE);
+        P256k1PrivKey priv = P256k1PrivKey.of(BigInteger.ONE);
 
         BigInteger privInt = priv.getS();
         Assertions.assertEquals(BigInteger.ONE, privInt);

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/Secp256k1ForeignTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/Secp256k1ForeignTest.java
@@ -15,8 +15,8 @@
  */
 package org.bitcoinj.secp.integration;
 
+import org.bitcoinj.secp.api.P256k1PrivKey;
 import org.bitcoinj.secp.api.P256k1PubKey;
-import org.bitcoinj.secp.bouncy.BouncyPrivKey;
 import org.bitcoinj.secp.ffm.Secp256k1Foreign;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ public class Secp256k1ForeignTest {
     @Test
     void pubKeyAdditionTestOne() {
         try (Secp256k1Foreign secp = new Secp256k1Foreign()) {
-            P256k1PubKey pubKey = secp.ecKeyPairCreate(new BouncyPrivKey(BigInteger.ONE)).getPublic();
+            P256k1PubKey pubKey = secp.ecKeyPairCreate(P256k1PrivKey.of(BigInteger.ONE)).getPublic();
             P256k1PubKey added = secp.ecPubKeyCombine(pubKey);
             P256k1PubKey multiplied = secp.ecPubKeyTweakMul(pubKey, BigInteger.valueOf(1));
             Assertions.assertEquals(added.getW(), multiplied.getW());
@@ -40,7 +40,7 @@ public class Secp256k1ForeignTest {
     @Test
     void pubKeyAdditionTestTwo() {
         try (Secp256k1Foreign secp = new Secp256k1Foreign()) {
-            P256k1PubKey pubKey = secp.ecKeyPairCreate(new BouncyPrivKey(BigInteger.ONE)).getPublic();
+            P256k1PubKey pubKey = secp.ecKeyPairCreate(P256k1PrivKey.of(BigInteger.ONE)).getPublic();
             P256k1PubKey added = secp.ecPubKeyCombine(pubKey, pubKey);
             P256k1PubKey multiplied = secp.ecPubKeyTweakMul(pubKey, BigInteger.valueOf(2));
             Assertions.assertEquals(added.getW(), multiplied.getW());


### PR DESCRIPTION
It's now possible to write integration tests without a dependency on the Bouncy implementation.

This is a child of PR #161.
