### PR TITLE
Add ECDH secret computation to secp-api, secp-ffm, and secp-bouncy

### DIFF
--- a/extract-headers.sh
+++ b/extract-headers.sh
@@ -10,4 +10,5 @@ jextract --target-package org.bitcoinj.secp.ffm.jextract \
         --use-system-load-library \
         -lsecp256k1 \
         --header-class-name secp256k1_h \
-        $INC_PATH/secp256k1_schnorrsig.h
+        $INC_PATH/secp256k1_schnorrsig.h \
+        $INC_PATH/secp256k1_ecdh.h

--- a/secp-api/src/main/java/org/bitcoinj/secp/api/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/api/Secp256k1.java
@@ -90,6 +90,8 @@ public interface Secp256k1 extends Closeable {
 
     Result<Boolean> schnorrSigVerify(byte[] signature, byte[] msg_hash, P256K1XOnlyPubKey pubKey);
 
+    Result<byte[]> ecdh(P256k1PubKey pubKey, P256k1PrivKey secKey);
+
     /**
      * Override close and declare that no checked exceptions are thrown
      */

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_h.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_h.java
@@ -3143,6 +3143,159 @@ public class secp256k1_h {
            throw new AssertionError("should not reach here", ex$);
         }
     }
+
+    private static class secp256k1_ecdh_hash_function_sha256$constants {
+        public static final AddressLayout LAYOUT = secp256k1_h.C_POINTER;
+        public static final MemorySegment SEGMENT = secp256k1_h.findOrThrow("secp256k1_ecdh_hash_function_sha256").reinterpret(LAYOUT.byteSize());
+    }
+
+    /**
+     * Layout for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_sha256
+     * }
+     */
+    public static AddressLayout secp256k1_ecdh_hash_function_sha256$layout() {
+        return secp256k1_ecdh_hash_function_sha256$constants.LAYOUT;
+    }
+
+    /**
+     * Segment for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_sha256
+     * }
+     */
+    public static MemorySegment secp256k1_ecdh_hash_function_sha256$segment() {
+        return secp256k1_ecdh_hash_function_sha256$constants.SEGMENT;
+    }
+
+    /**
+     * Getter for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_sha256
+     * }
+     */
+    public static MemorySegment secp256k1_ecdh_hash_function_sha256() {
+        return secp256k1_ecdh_hash_function_sha256$constants.SEGMENT.get(secp256k1_ecdh_hash_function_sha256$constants.LAYOUT, 0L);
+    }
+
+    /**
+     * Setter for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_sha256
+     * }
+     */
+    public static void secp256k1_ecdh_hash_function_sha256(MemorySegment varValue) {
+        secp256k1_ecdh_hash_function_sha256$constants.SEGMENT.set(secp256k1_ecdh_hash_function_sha256$constants.LAYOUT, 0L, varValue);
+    }
+
+    private static class secp256k1_ecdh_hash_function_default$constants {
+        public static final AddressLayout LAYOUT = secp256k1_h.C_POINTER;
+        public static final MemorySegment SEGMENT = secp256k1_h.findOrThrow("secp256k1_ecdh_hash_function_default").reinterpret(LAYOUT.byteSize());
+    }
+
+    /**
+     * Layout for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_default
+     * }
+     */
+    public static AddressLayout secp256k1_ecdh_hash_function_default$layout() {
+        return secp256k1_ecdh_hash_function_default$constants.LAYOUT;
+    }
+
+    /**
+     * Segment for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_default
+     * }
+     */
+    public static MemorySegment secp256k1_ecdh_hash_function_default$segment() {
+        return secp256k1_ecdh_hash_function_default$constants.SEGMENT;
+    }
+
+    /**
+     * Getter for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_default
+     * }
+     */
+    public static MemorySegment secp256k1_ecdh_hash_function_default() {
+        return secp256k1_ecdh_hash_function_default$constants.SEGMENT.get(secp256k1_ecdh_hash_function_default$constants.LAYOUT, 0L);
+    }
+
+    /**
+     * Setter for variable:
+     * {@snippet lang=c :
+     * extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_default
+     * }
+     */
+    public static void secp256k1_ecdh_hash_function_default(MemorySegment varValue) {
+        secp256k1_ecdh_hash_function_default$constants.SEGMENT.set(secp256k1_ecdh_hash_function_default$constants.LAYOUT, 0L, varValue);
+    }
+
+    private static class secp256k1_ecdh {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            secp256k1_h.C_INT,
+            secp256k1_h.C_POINTER,
+            secp256k1_h.C_POINTER,
+            secp256k1_h.C_POINTER,
+            secp256k1_h.C_POINTER,
+            secp256k1_h.C_POINTER,
+            secp256k1_h.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = secp256k1_h.findOrThrow("secp256k1_ecdh");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * extern int secp256k1_ecdh(const secp256k1_context *ctx, unsigned char *output, const secp256k1_pubkey *pubkey, const unsigned char *seckey, secp256k1_ecdh_hash_function hashfp, void *data)
+     * }
+     */
+    public static FunctionDescriptor secp256k1_ecdh$descriptor() {
+        return secp256k1_ecdh.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * extern int secp256k1_ecdh(const secp256k1_context *ctx, unsigned char *output, const secp256k1_pubkey *pubkey, const unsigned char *seckey, secp256k1_ecdh_hash_function hashfp, void *data)
+     * }
+     */
+    public static MethodHandle secp256k1_ecdh$handle() {
+        return secp256k1_ecdh.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * extern int secp256k1_ecdh(const secp256k1_context *ctx, unsigned char *output, const secp256k1_pubkey *pubkey, const unsigned char *seckey, secp256k1_ecdh_hash_function hashfp, void *data)
+     * }
+     */
+    public static MemorySegment secp256k1_ecdh$address() {
+        return secp256k1_ecdh.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * extern int secp256k1_ecdh(const secp256k1_context *ctx, unsigned char *output, const secp256k1_pubkey *pubkey, const unsigned char *seckey, secp256k1_ecdh_hash_function hashfp, void *data)
+     * }
+     */
+    public static int secp256k1_ecdh(MemorySegment ctx, MemorySegment output, MemorySegment pubkey, MemorySegment seckey, MemorySegment hashfp, MemorySegment data) {
+        var mh$ = secp256k1_ecdh.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("secp256k1_ecdh", ctx, output, pubkey, seckey, hashfp, data);
+            }
+            return (int)mh$.invokeExact(ctx, output, pubkey, seckey, hashfp, data);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
     private static final MemorySegment NULL = MemorySegment.ofAddress(0L);
     /**
      * {@snippet lang=c :

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdhTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdhTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023-2024 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.integration;
+
+import org.bitcoinj.secp.api.P256k1PrivKey;
+import org.bitcoinj.secp.api.P256k1PubKey;
+import org.bitcoinj.secp.api.Result;
+import org.bitcoinj.secp.api.Secp256k1;
+import org.bitcoinj.secp.bouncy.Bouncy256k1;
+import org.bitcoinj.secp.ffm.Secp256k1Foreign;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+// TODO: Use test vectors from: https://github.com/C2SP/wycheproof/blob/master/testvectors/ecdh_secp256k1_test.json ??
+public class EcdhTest {
+    @Test
+    void ecdhSmokeTest() {
+        try (Secp256k1 secp = new Secp256k1Foreign()) {
+            P256k1PrivKey secKey = P256k1PrivKey.of(BigInteger.ONE);
+            P256k1PubKey pubKey = secp.ecPubKeyCreate(secKey);
+            Result<byte[]> result = secp.ecdh(pubKey, secKey);
+            Assertions.assertNotNull(result);
+            Assertions.assertInstanceOf(Result.Ok.class, result);
+            Assertions.assertEquals(32, result.get().length);
+        }
+    }
+
+    @Test
+    void ecdhSameTest() {
+        try (Secp256k1 secp = new Secp256k1Foreign()) {
+            P256k1PrivKey secKey1 = secp.ecPrivKeyCreate();
+            P256k1PubKey pubKey1 = secp.ecPubKeyCreate(secKey1);
+
+            P256k1PrivKey secKey2 = secp.ecPrivKeyCreate();
+            P256k1PubKey pubKey2 = secp.ecPubKeyCreate(secKey2);
+
+            // Compute shared secret with secKey1
+            Result<byte[]> result1 = secp.ecdh(pubKey2, secKey1);
+            Assertions.assertNotNull(result1);
+            Assertions.assertInstanceOf(Result.Ok.class, result1);
+            Assertions.assertEquals(32, result1.get().length);
+
+            // Compute shared secret with secKey2
+            Result<byte[]> result2 = secp.ecdh(pubKey1, secKey2);
+            Assertions.assertNotNull(result1);
+            Assertions.assertInstanceOf(Result.Ok.class, result2);
+            Assertions.assertEquals(32, result2.get().length);
+
+            // The separately computed shared secrets should be equal
+            Assertions.assertArrayEquals(result1.get(), result2.get());
+        }
+    }
+
+    @Test
+    void ecdhSmokeTestBouncy() {
+        try (Secp256k1 secp = new Bouncy256k1()) {
+            P256k1PrivKey secKey = P256k1PrivKey.of(BigInteger.ONE);
+            P256k1PubKey pubKey = secp.ecPubKeyCreate(secKey);
+            Result<byte[]> result = secp.ecdh(pubKey, secKey);
+            Assertions.assertNotNull(result);
+            Assertions.assertInstanceOf(Result.Ok.class, result);
+            Assertions.assertEquals(32, result.get().length);
+        }
+    }
+
+    @Test
+    void ecdhSameTestBouncy() {
+        try (Secp256k1 secp = new Bouncy256k1()) {
+            P256k1PrivKey secKey1 = secp.ecPrivKeyCreate();
+            P256k1PubKey pubKey1 = secp.ecPubKeyCreate(secKey1);
+
+            P256k1PrivKey secKey2 = secp.ecPrivKeyCreate();
+            P256k1PubKey pubKey2 = secp.ecPubKeyCreate(secKey2);
+
+            // Compute shared secret with secKey1
+            Result<byte[]> result1 = secp.ecdh(pubKey2, secKey1);
+            Assertions.assertNotNull(result1);
+            Assertions.assertInstanceOf(Result.Ok.class, result1);
+            Assertions.assertEquals(32, result1.get().length);
+
+            // Compute shared secret with secKey2
+            Result<byte[]> result2 = secp.ecdh(pubKey1, secKey2);
+            Assertions.assertNotNull(result1);
+            Assertions.assertInstanceOf(Result.Ok.class, result2);
+            Assertions.assertEquals(32, result2.get().length);
+
+            // The separately computed shared secrets should be equal
+            Assertions.assertArrayEquals(result1.get(), result2.get());
+        }
+    }
+
+    @Test
+    void ecdhResultCompare() {
+        try (Secp256k1Foreign secp1 = new Secp256k1Foreign(); Bouncy256k1 secp2 = new Bouncy256k1()) {
+            P256k1PrivKey secKey = P256k1PrivKey.of(BigInteger.ONE);
+            P256k1PubKey pubKey = secp1.ecPubKeyCreate(secKey);
+            Result<byte[]> result1 = secp1.ecdh(pubKey, secKey);
+            Result<byte[]> result2 = secp2.ecdh(pubKey, secKey);
+            Assertions.assertArrayEquals(result1.get(), result2.get());
+        }
+    }
+
+    @Test
+    void ecdhSameTestCrossCheck() {
+        try (Secp256k1 secp1 = new Secp256k1Foreign(); Secp256k1 secp2 = new Bouncy256k1()) {
+            P256k1PrivKey secKey1 = secp1.ecPrivKeyCreate();
+            P256k1PubKey pubKey1 = secp1.ecPubKeyCreate(secKey1);
+
+            P256k1PrivKey secKey2 = secp2.ecPrivKeyCreate();
+            P256k1PubKey pubKey2 = secp2.ecPubKeyCreate(secKey2);
+
+            // Compute shared secret with secKey1 and secp1 (implementation 1)
+            Result<byte[]> result1 = secp1.ecdh(pubKey2, secKey1);
+            Assertions.assertNotNull(result1);
+            Assertions.assertInstanceOf(Result.Ok.class, result1);
+            Assertions.assertEquals(32, result1.get().length);
+
+            // Compute shared secret with secKey2 and secp2 (implementation 2)
+            Result<byte[]> result2 = secp2.ecdh(pubKey1, secKey2);
+            Assertions.assertNotNull(result1);
+            Assertions.assertInstanceOf(Result.Ok.class, result2);
+            Assertions.assertEquals(32, result2.get().length);
+
+            // The separately computed shared secrets should be equal
+            Assertions.assertArrayEquals(result1.get(), result2.get());
+        }
+    }
+}


### PR DESCRIPTION
This is based on the API and implementation in libsecp256k1, but is also implemented via Bouncy Castle.