### PR TITLE
Require JDK 24, update GHA and GitLab CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew -PjavaToolchainVersion=24 build
+        run: ./gradlew build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew -PjavaToolchainVersion=24 run runEcdsa
+        run: ./gradlew run runEcdsa
 
 
   build_nix:
@@ -60,4 +60,4 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build in Nix development shell
-        run: nix develop -c gradle -PjavaToolchainVersion=24 build run runEcdsa
+        run: nix develop -c gradle build run runEcdsa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,26 +17,26 @@ nixos-devshell:
       - /nix/store
       - ~/.gradle/
 
-# Build on Trixie using Debian's OpenJDK 23, Gradle via the Wrapper and secp256k1 installed via `nix profile install`.
-# When Trixie is finalized, JDK 23 will probably be dropped, and we will need to use Nix to install a JDK.
+# Build on Trixie using Nix to install OpenJDK 24 and secp256k1 with Gradle installed via the Wrapper.
 trixie-gradlew:
   image: debian:trixie-slim
   before_script:
     - apt-get update
-    - apt-get -y install openjdk-23-jdk-headless nix-setup-systemd
+    - apt-get -y install nix-setup-systemd
     - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
-    - nix profile install nixpkgs#secp256k1
+    - nix profile install nixpkgs#secp256k1 nixpkgs#jdk24
   script:
+    - export JAVA_HOME=$(nix eval --raw nixpkgs#jdk24.outPath)
     - ./gradlew build run runEcdsa
 
-# Build on Sid (Forky) using Debian's OpenJDK 23, Gradle via the Wrapper and secp256k1 installed via `nix profile install`.
-# Sid/Forky should eventually have an LTS OpenJDK 25 which is our target version for a production-quality release of
-# secp256k1-jdk. If we're lucky it might even get a Debian Gradle we can use. If so, we can make a Forky build that doesn't need Nix.
+# Build on Sid (Forky) using Debian's OpenJDK 24, Gradle via the Wrapper and secp256k1 installed via `nix profile install`.
+# Sid/Forky should eventually have an LTS OpenJDK 25, which is our target version for a production-quality release of
+# secp256k1-jdk. If we're lucky, it might even get a Debian Gradle we can use. If so, we can make a Forky build that doesn't need Nix.
 forky-gradlew:
   image: debian:sid-slim
   before_script:
     - apt-get update
-    - apt-get -y install openjdk-23-jdk-headless nix-setup-systemd
+    - apt-get -y install openjdk-24-jdk-headless nix-setup-systemd
     - echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
     - nix profile install nixpkgs#secp256k1
   script:

--- a/README.adoc
+++ b/README.adoc
@@ -24,14 +24,14 @@ The API is distributed as an API-only JAR (```secp-api-_version_.jar```) and we 
 
 NOTE:: At this point, we are especially interested in feedback on the API.
 
-== libsecp256k1 Panama Implementation (JDK 23+)
+== libsecp256k1 Panama Implementation (JDK 24+)
 
-The provided proof-of-concept implementation uses the https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1] C-language library via https://openjdk.org/jeps/454[JEP-454: Foreign Function & Memory API] (known as **Panama**.) It is provided in a separate JAR (```secp-ffm-_version_.jar```) that requires JDK 23 or later.
+The provided proof-of-concept implementation uses the https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1] C-language library via https://openjdk.org/jeps/454[JEP-454: Foreign Function & Memory API] (known as **Panama**.) It is provided in a separate JAR (```secp-ffm-_version_.jar```) that requires JDK 24 or later.
 
 Panama was released as part of https://openjdk.org/projects/jdk/22/[OpenJDK 22]. We anticipate `secp-ffm` will be
 the recommended/preferred `secp-api` implementation for use in projects using modern JVMs.
 
-The minimum required JDK for this module will likely be incremented with each new JDK release, with a target of requiring JDK 25 (the next LTS release of the JDK) for the 1.0 release of `secp-ffm`.
+The minimum required JDK for the `secp-ffm` module will be incremented to JDK 25 (the next LTS release of the JDK) before the 1.0 release of `secp256k1-jdk`.
 
 WARNING:: This is a preliminary implementation provided for experimentation and feedback and should not be used in real applications.
 
@@ -63,7 +63,7 @@ The SECG secp256K1 curve was removed from Java in the JDK 16 release (see https:
 
 == Current Build Status
 
-The build requires JDK 23 installed to run. Gradle 8.13 should be used and is provided by the included Gradle Wrapper.
+The build requires JDK 24 installed to run. Gradle 8.14 should be used and is provided by the included Gradle Wrapper.
 
 == Installing libsecp256k into your profile with Nix
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 secpVersion = 0.2-SNAPSHOT
 
 # Major (whole number) version of JDK to use for javac, jlink, jpackage, etc.
-javaToolchainVersion = 23
+javaToolchainVersion = 24
 # Vendor for javaToolChain. (Should be indicator string from Gradle's KnownJvmVendor enum or empty string)
 # Official builds use 'Eclipse Adoptium'
 #javaToolchainVendor = Eclipse Adoptium
 javaToolchainVendor =
 
 # Where to look for JDKs (via environment variables)
-org.gradle.java.installations.fromEnv = JAVA_HOME, JDK23, JDK24
+org.gradle.java.installations.fromEnv = JAVA_HOME, JDK24
 
 # Auto-detection can be disabled if you have multiple JDKs of the
 # same version installed and Gradle won't reliably select the version you actually want


### PR DESCRIPTION
`gradle.properties`:

* set `javaToolchainVersion = 24`
* Remove use of the `JDK23` environment variable

GHA `gradle.yml`:

* Remove `javaToolchainVersion` override in gradle commands

`.gitlab_ci.yml`:

* Upgrade to JDK 24. For the Trixie build we now install JDK 24 via Nix because (non-LTS) JDK 24 has been removed from Trixie.

`README.adoc`:

* Update to say JDK 24 and Gradle 8.14 are required, etc.

Note that `options.release` in the Gradle build files is still set to `23`, so it is currently still possible to build with JDK 23 by using `-PjavaToolchainVersion=23`, but that will change soon.
