### PR TITLE
Add direnv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .gradle/
 build/
 secp-*/bin/
+.direnv/
+.envrc

--- a/envrc.template
+++ b/envrc.template
@@ -1,0 +1,7 @@
+# This file tells direnv to load our Nix flake environment
+# Documentation: https://direnv.net/
+# For convenience, `envrc.template` is checked in to git and can be copied to `.envrc`
+
+# 'use flake' is a direnv command that activates the Nix flake in this directory
+# It's equivalent to running 'nix develop' but automatic
+use flake


### PR DESCRIPTION
See https://direnv.net

This PR just adds `.direnv/` and `.envrc` to `.gitignore` and provides `envrc.template` which can be copied to `.envrc`.

The `envrc.template` contains the `use flake` command that will do the equivalent of `nix develop` when the user cd's into the project directory (after having used `direnv allow`, of course)