### PR TITLE
GHA gradle.yml: Use java-version 25-ea

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-14]
         distribution: ['temurin']
       fail-fast: false
-    name: ${{ matrix.os }} JDK 24 (via Gradle Java toolchains)
+    name: ${{ matrix.os }} JDK 25-ea (via Gradle Java toolchains)
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -28,8 +28,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           # When installing multiple JDKs, the last JDK installed is the default and will be used to run Gradle itself
           java-version: |
-            24
-            23
+            25-ea
           cache: 'gradle'
       - name: Install Nix
         uses: cachix/install-nix-action@v30
@@ -38,9 +37,9 @@ jobs:
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew -PjavaToolchainVersion=25 build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew run runEcdsa
+        run: ./gradlew -PjavaToolchainVersion=25 run runEcdsa
 
 
   build_nix:


### PR DESCRIPTION
Note: We use -PjavaToolchainVersion=25 to override the default javaToolchainVersion of 24 which remains set in gradle.properties