### PR TITLE
build.gradle, flake.nix: use (DY)LID_LIBRARY_PATH to find libsecp256k1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,6 +36,10 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install secp256k1 with Nix
         run: nix profile install nixpkgs#secp256k1
+      - name: Set library path
+        run: |
+          echo "LD_LIBRARY_PATH=$HOME/.nix-profile/lib:${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$HOME/.nix-profile/lib:${DYLD_LIBRARY_PATH:-}" >> $GITHUB_ENV
       - name: Build with Gradle
         run: ./gradlew -PjavaToolchainVersion=25 build
       - name: Run Java & Kotlin Examples

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,6 @@ subprojects { sub ->
 
     test {
         useJUnitPlatform()
-        def userHome = System.getProperty("user.home")
-        systemProperty "java.library.path", findProperty("javaPath") ?: "${userHome}/.nix-profile/lib"
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,11 @@
       perSystem = { config, self', inputs', pkgs, system, lib, ... }: let
         inherit (pkgs) stdenv;
         sharedShellHook = ''
+            if [[ "$(uname)" == "Darwin" ]]; then
+              export DYLD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.secp256k1 ]}:$DYLD_LIBRARY_PATH"
+            else
+              export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.secp256k1 ]}:$LD_LIBRARY_PATH"
+            fi
             echo "Welcome to secp256k1-jdk!"
         '';
       in {

--- a/secp-examples-java/build.gradle
+++ b/secp-examples-java/build.gradle
@@ -29,11 +29,7 @@ application {
     mainClass = 'org.bitcoinj.secp.examples.Schnorr'
 }
 
-def userHome = System.getProperty("user.home")
-def javaLibraryPath = findProperty("javaPath") ?: "${userHome}/.nix-profile/lib"
-
 run {
-    systemProperty "java.library.path", javaLibraryPath
     jvmArgs += '--enable-native-access=org.bitcoinj.secp.ffm'
 }
 
@@ -41,7 +37,6 @@ tasks.register('runEcdsa', JavaExec) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(javaToolchainVersion)
     }
-    systemProperty "java.library.path", javaLibraryPath
     classpath = sourceSets.main.runtimeClasspath
     mainModule = 'org.bitcoinj.secp.examples'
     mainClass = 'org.bitcoinj.secp.examples.Ecdsa'

--- a/secp-examples-kotlin/build.gradle
+++ b/secp-examples-kotlin/build.gradle
@@ -20,11 +20,7 @@ application {
     mainClass = 'org.bitcoinj.secp.kotlin.examples.SchnorrKt'
 }
 
-def userHome = System.getProperty("user.home")
-def javaLibraryPath = findProperty("javaPath") ?: "${userHome}/.nix-profile/lib"
-
 run {
-    systemProperty "java.library.path", javaLibraryPath
     jvmArgs += '--enable-native-access=ALL-UNNAMED'
 }
 
@@ -32,7 +28,6 @@ tasks.register('runEcdsa', JavaExec) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(javaToolchainVersion)
     }
-    systemProperty "java.library.path", javaLibraryPath
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.bitcoinj.secp.kotlin.examples.EcdsaKt'
     jvmArgs += '--enable-native-access=ALL-UNNAMED'


### PR DESCRIPTION
Rather than using `${userHome}/.nix-profile/lib` as the default in the Gradle build (and allowing override with `javaPath`), require that (DY)LID_LIBRARY_PATH be set in the environment that calls Gradle and configure the Nix devShells to set it up correctly.

The first commit adds a minimal shell hook that adds a welcome message. The second commit is the main commit.
