### PR TITLE
flake.nix: upgrade from gradle to gradle_9

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
                 jdk24                      # JDK 24 will be in PATH
                 # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
                 # jextract                 # jextract (Nix package) contains a jlinked executable and bundles its own JDK
-                (gradle.override {         # Gradle 8.x (Nix package) runs using an internally-linked JDK
+                (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
                     java = jdk24;          # Run Gradle with this JDK
                 })
             ];
@@ -42,7 +42,7 @@
         devShells.minimum = pkgs.mkShell {
           inputsFrom = with pkgs ; [ secp256k1 ];
           packages = with pkgs ; [
-                (gradle.override {         # Gradle 8.x (Nix package) runs using an internally-linked JDK
+                (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
                     java = jdk24_headless; # Run Gradle with this JDK
                 })
             ];


### PR DESCRIPTION
`gradle` is currently `gradle_8`, this upgrades to gradle_9 (which is currently 9.0.0)

(When 9.1.0 is available we'll just need a `nix flake update`)