### PR TITLE
flake.nix: upgrade to GraalVM 25-EA

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             echo "Welcome to secp256k1-jdk!"
         '';
       in {
+        _module.args.pkgs = pkgs;
         # define default devshell, with a richer collection of tools intended for interactive development
         devShells.default = pkgs.mkShell {
           inputsFrom = with pkgs ; [ secp256k1 ];


### PR DESCRIPTION
`gradle` is currently `gradle_8`, this upgrades to gradle_9 (which is currently 9.0.0)