### PR TITLE
.gitlab-ci.yml: 3h timeout for nix-devshell

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 # Build on minimal Nix image using the devshell from `flake.nix`
 nix-devshell:
+  timeout: 3h   # long timeout in case of unexpected rebuilds of packages from source
   image: nixos/nix:latest
   variables:
     NIXPKGS_URL: "github:NixOS/nixpkgs/nixos-unstable"


### PR DESCRIPTION
Sometimes packages (e.g. graalvm) may need to be
rebuilt instead of loading from cache. Allow more time to do this.