### PR TITLE
Java Example Native Image Compilation on GraalVM 25

### DIFF
--- a/secp-examples-java/build.gradle
+++ b/secp-examples-java/build.gradle
@@ -7,6 +7,7 @@ ext.moduleName = 'org.bitcoinj.secp.examples'
 
 dependencies {
     implementation project(':secp-api')
+    implementation project(':secp-graalvm')
     runtimeOnly project(':secp-bouncy')
     runtimeOnly project(':secp-ffm')
 }
@@ -20,6 +21,7 @@ jar {
     inputs.property("moduleName", moduleName)
     manifest {
         attributes  'Implementation-Title': 'Example secp256k1-jdk Apps',
+                'Main-Class': application.mainClass,
                 'Implementation-Version': archiveVersion.get()
     }
 }
@@ -34,6 +36,11 @@ run {
     jvmArgs += '--enable-native-access=org.bitcoinj.secp.ffm'
 }
 
+configurations {
+    nativeToolImplementation.extendsFrom implementation
+    nativeToolRuntimeOnly.extendsFrom runtimeOnly
+}
+
 tasks.register('runEcdsa', JavaExec) {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(javaToolchainVersion)
@@ -42,4 +49,62 @@ tasks.register('runEcdsa', JavaExec) {
     mainModule = 'org.bitcoinj.secp.examples'
     mainClass = 'org.bitcoinj.secp.examples.Ecdsa'
     jvmArgs += '--enable-native-access=org.bitcoinj.secp.ffm'
+}
+
+tasks.register('nativeCompile') {
+    dependsOn 'nativeCompileSchnorr', 'nativeCompileEcdsa'
+}
+
+// Compile a native image using GraalVM's native-image tool
+// Graal must be installed at $GRAALVM_HOME
+tasks.register('nativeCompileSchnorr', Exec) {
+    dependsOn jar
+    workingDir = projectDir
+    executable = "${System.env.GRAALVM_HOME}/bin/native-image"
+    args = ['--verbose',
+            '--no-fallback',
+            '--module', 'org.bitcoinj.secp.examples/org.bitcoinj.secp.examples.Schnorr',
+            '--module-path', jar.archiveFile.get(),
+            '--module-path', "${-> configurations.nativeToolImplementation.asPath}", // Lazy configuration resolution
+            '--module-path', "${-> configurations.nativeToolRuntimeOnly.asPath}",   // Lazy configuration resolution
+            '--add-modules', 'org.bitcoinj.secp.ffm',
+            '--enable-native-access=org.bitcoinj.secp.ffm',
+            '-H:Path=build',
+            '-H:Name=schnorr-example',
+            '-H:+ForeignAPISupport',
+            '-H:+SharedArenaSupport',
+            '-H:-CheckToolchain',
+            '--features=org.bitcoinj.secp.graalvmffm.ForeignRegistrationFeature',
+            '--enable-native-access=ALL-UNNAMED',
+            '-H:+ReportUnsupportedElementsAtRuntime',
+            '-H:+ReportExceptionStackTraces'
+    ]
+}
+
+// Compile a native image using GraalVM's native-image tool
+// Graal must be installed at $GRAALVM_HOME
+// THIS IS NOT WORKING YET, THERE'S A PROBLEM AT RUNTIME:
+// "Cannot perform downcall with leaf type (long,long,long,long,long)int as it was not registered at compilation time"
+tasks.register('nativeCompileEcdsa', Exec) {
+    dependsOn jar
+    workingDir = projectDir
+    executable = "${System.env.GRAALVM_HOME}/bin/native-image"
+    args = ['--verbose',
+            '--no-fallback',
+            '--module', 'org.bitcoinj.secp.examples/org.bitcoinj.secp.examples.Ecdsa',
+            '--module-path', jar.archiveFile.get(),
+            '--module-path', "${-> configurations.nativeToolImplementation.asPath}", // Lazy configuration resolution
+            '--module-path', "${-> configurations.nativeToolRuntimeOnly.asPath}",   // Lazy configuration resolution
+            '--add-modules', 'org.bitcoinj.secp.ffm',
+            '--enable-native-access=org.bitcoinj.secp.ffm',
+            '-H:Path=build',
+            '-H:Name=ecdsa-example',
+            '-H:+ForeignAPISupport',
+            '-H:+SharedArenaSupport',
+            '-H:-CheckToolchain',
+            '--features=org.bitcoinj.secp.graalvmffm.ForeignRegistrationFeature',
+            '--enable-native-access=ALL-UNNAMED',
+            '-H:+ReportUnsupportedElementsAtRuntime',
+            '-H:+ReportExceptionStackTraces'
+    ]
 }

--- a/secp-graalvm/build.gradle
+++ b/secp-graalvm/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java-library'
+}
+
+ext.moduleName = 'org.bitcoinj.secp.graalvm'
+
+dependencies {
+    api("org.jspecify:jspecify:1.0.0")
+    implementation group: 'org.graalvm.sdk', name: 'nativeimage', version: '24.2.2'
+}
+
+jar {
+    inputs.property("moduleName", moduleName)
+    manifest {
+        attributes  'Implementation-Title': 'Secp256k1 GraalVM Foreign Registration',
+                'Automatic-Module-Name': moduleName,
+                'Implementation-Version': archiveVersion.get()
+    }
+}

--- a/secp-graalvm/src/main/java/module-info.java
+++ b/secp-graalvm/src/main/java/module-info.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 @org.jspecify.annotations.NullMarked
-module org.bitcoinj.secp.examples {
-    requires org.bitcoinj.secp.api;
-    requires org.bitcoinj.secp.graalvm;
+module org.bitcoinj.secp.graalvm {
+    requires org.graalvm.nativeimage;
     requires org.jspecify;
 }

--- a/secp-graalvm/src/main/java/org/bitcoinj/secp/graalvmffm/ForeignRegistrationFeature.java
+++ b/secp-graalvm/src/main/java/org/bitcoinj/secp/graalvmffm/ForeignRegistrationFeature.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-2024 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.graalvmffm;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeForeignAccess;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+
+import static java.lang.foreign.ValueLayout.*;
+
+/**
+ * Register secp methods for GraalVM Foreign Access
+ */
+public class ForeignRegistrationFeature implements Feature {
+    public void duringSetup(Feature.DuringSetupAccess access) {
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid());
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_LONG, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_LONG, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(JAVA_INT, JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_LONG, JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_LONG));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_INT, JAVA_INT));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.of(ADDRESS, JAVA_INT, JAVA_INT), Linker.Option.firstVariadicArg(1));
+        RuntimeForeignAccess.registerForDowncall(FunctionDescriptor.ofVoid(JAVA_INT), Linker.Option.captureCallState("errno"));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ rootProject.name = 'secp256k1-jdk'
 include 'secp-api'               // API interface library
 include 'secp-bouncy'            // Bouncy Castle implementation
 include 'secp-ffm'               // Java Foreign Memory & Function ("Panama") implementation
+include 'secp-graalvm'           // GraalVM Foreign Function Registration support
 include 'secp-bitcoinj'          // bitcoinj integration utilities and tests (P2TR address generation, etc.)
 include 'secp-integration-test'  // Integration tests of API implementations (ffm and bouncy)
 include 'secp-examples-java'     // Java examples


### PR DESCRIPTION
Add `secp-graalvm` with GraalVM FFM support for secp-ffm and enable native-image compilation of `schnorr-example`.
