### PR TITLE
Experiment: use jdk25 toolchain only

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756819007,
-        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
-        "owner": "nixos",
+        "lastModified": 1757000898,
+        "narHash": "sha256-6HbDHFltcXtx2LJ5kesNMuO0185Lkev0LvW1rEjbuP4=",
+        "owner": "nixpkgs-jdk-ea",
         "repo": "nixpkgs",
-        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
+        "rev": "6c59b63c0f95e847a81028bbd7329adc22ba55ef",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "owner": "nixpkgs-jdk-ea",
+        "ref": "jdk-ea-25",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
           config.allowUnfreePredicate = pkg:
             builtins.elem (pkgs.lib.getName pkg) allowedUnfree;
         };
+        jdk = pkgs.jdk24;
+        jdk-headless = pkgs.jdk24_headless;
         graalvm = pkgs.graalvmPackages.graalvm-oracle_25-ea;
         sharedShellHook = ''
             if [[ "$(uname)" == "Darwin" ]]; then
@@ -42,7 +44,7 @@
                 # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
                 # jextract                 # jextract (Nix package) contains a jlinked executable and bundles its own JDK
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
-                    java = jdk24;          # Run Gradle with this JDK
+                    java = jdk;            # Run Gradle with this JDK
                 })
             ];
           shellHook = sharedShellHook;
@@ -53,7 +55,7 @@
           packages = with pkgs ; [
                 graalvm                    # This JDK will be in PATH
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
-                    java = jdk24_headless; # Run Gradle with this JDK
+                    java = jdk-headless;   # Run Gradle with this JDK
                 })
             ];
           shellHook = sharedShellHook;

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "secp2565k1-jdk (Java API & implementations for secp256k1)";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixpkgs-jdk-ea/nixpkgs/jdk-ea-25";  # Nixpkgs URL with Gradle 9.1.0-rc-x available
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
                 # jextract                 # jextract (Nix package) contains a jlinked executable and bundles its own JDK
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
                     java = jdk;            # Run Gradle with this JDK
+                    javaToolchains = [ graalvm ];   # Add graalvm via toolchains so we can have Java 25
                 })
             ];
           shellHook = sharedShellHook;
@@ -56,6 +57,7 @@
                 graalvm                    # This JDK will be in PATH
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
                     java = jdk-headless;   # Run Gradle with this JDK
+                    javaToolchains = [ graalvm ];   # Add graalvm via toolchains so we can have Java 25
                 })
             ];
           shellHook = sharedShellHook;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 secpVersion = 0.2-SNAPSHOT
 
 # Major (whole number) version of JDK to use for javac, jlink, jpackage, etc.
-javaToolchainVersion = 24
+javaToolchainVersion = 25
 # Vendor for javaToolChain. (Should be indicator string from Gradle's KnownJvmVendor enum or empty string)
 # Official builds use 'Eclipse Adoptium'
 #javaToolchainVendor = Eclipse Adoptium
 javaToolchainVendor =
 
 # Where to look for JDKs (via environment variables)
-org.gradle.java.installations.fromEnv = JAVA_HOME, JDK24
+org.gradle.java.installations.fromEnv = JAVA_HOME, JDK25
 
 # Auto-detection can be disabled if you have multiple JDKs of the
 # same version installed and Gradle won't reliably select the version you actually want

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,9 +5,6 @@ include 'secp-bouncy'            // Bouncy Castle implementation
 include 'secp-ffm'               // Java Foreign Memory & Function ("Panama") implementation
 include 'secp-bitcoinj'          // bitcoinj integration utilities and tests (P2TR address generation, etc.)
 include 'secp-integration-test'  // Integration tests of API implementations (ffm and bouncy)
-// Skip this module on JDK 24 builds until all our CI can upgrade to JDK 25
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
-    include 'secp-examples-java'     // Java examples
-}
+include 'secp-examples-java'     // Java examples
 include 'secp-examples-kotlin'   // Kotlin examples
 


### PR DESCRIPTION
There seems to be no advantage to doing this versus: PR #206 

I was hoping we might be able to make it work without Gradle 9.1, but Gradle 9.1 seems to be required even for building Java 25 with toolchains.