### PR TITLE
Update build to javaToolchainVersion = 25

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,9 +41,9 @@ jobs:
           echo "LD_LIBRARY_PATH=$HOME/.nix-profile/lib:${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=$HOME/.nix-profile/lib:${DYLD_LIBRARY_PATH:-}" >> $GITHUB_ENV
       - name: Build with Gradle
-        run: ./gradlew -PjavaToolchainVersion=25 build
+        run: ./gradlew build
       - name: Run Java & Kotlin Examples
-        run: ./gradlew -PjavaToolchainVersion=25 run runEcdsa
+        run: ./gradlew run runEcdsa
 
 
   build_nix:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ trixie-gradlew:
     - apt-get update
     - apt-get -y install openjdk-25-jdk-headless libsecp256k1-2 libsecp256k1-dev
   script:
-    - ./gradlew -PjavaToolchainVersion=25 build run runEcdsa
+    - ./gradlew build run runEcdsa
 
 # Build on Forky using Debian's OpenJDK 25 and libsecp256k1 with Gradle installed via the Wrapper.
 # If we're lucky, Forky might even get a Debian Gradle we can use. If so, we can stop using the Wrapper.
@@ -44,4 +44,4 @@ forky-gradlew:
     - apt-get update
     - apt-get -y install openjdk-25-jdk-headless libsecp256k1-2 libsecp256k1-dev
   script:
-    - ./gradlew -PjavaToolchainVersion=25 build run runEcdsa
+    - ./gradlew build run runEcdsa

--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756819007,
-        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
-        "owner": "nixos",
+        "lastModified": 1757000898,
+        "narHash": "sha256-6HbDHFltcXtx2LJ5kesNMuO0185Lkev0LvW1rEjbuP4=",
+        "owner": "nixpkgs-jdk-ea",
         "repo": "nixpkgs",
-        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
+        "rev": "6c59b63c0f95e847a81028bbd7329adc22ba55ef",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "owner": "nixpkgs-jdk-ea",
+        "ref": "jdk-ea-25",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "secp2565k1-jdk (Java API & implementations for secp256k1)";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixpkgs-jdk-ea/nixpkgs/jdk-ea-25";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -42,7 +42,7 @@
                 # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
                 # jextract                 # jextract (Nix package) contains a jlinked executable and bundles its own JDK
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
-                    java = jdk24;          # Run Gradle with this JDK
+                    java = graalvm;        # Run Gradle with this JDK
                 })
             ];
           shellHook = sharedShellHook;
@@ -53,7 +53,7 @@
           packages = with pkgs ; [
                 graalvm                    # This JDK will be in PATH
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
-                    java = jdk24_headless; # Run Gradle with this JDK
+                    java = graalvm;        # Run Gradle with this JDK
                 })
             ];
           shellHook = sharedShellHook;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 secpVersion = 0.2-SNAPSHOT
 
 # Major (whole number) version of JDK to use for javac, jlink, jpackage, etc.
-javaToolchainVersion = 24
+javaToolchainVersion = 25
 # Vendor for javaToolChain. (Should be indicator string from Gradle's KnownJvmVendor enum or empty string)
 # Official builds use 'Eclipse Adoptium'
 #javaToolchainVendor = Eclipse Adoptium
 javaToolchainVendor =
 
 # Where to look for JDKs (via environment variables)
-org.gradle.java.installations.fromEnv = JAVA_HOME, JDK24
+org.gradle.java.installations.fromEnv = JAVA_HOME, JDK25
 
 # Auto-detection can be disabled if you have multiple JDKs of the
 # same version installed and Gradle won't reliably select the version you actually want

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,9 +5,6 @@ include 'secp-bouncy'            // Bouncy Castle implementation
 include 'secp-ffm'               // Java Foreign Memory & Function ("Panama") implementation
 include 'secp-bitcoinj'          // bitcoinj integration utilities and tests (P2TR address generation, etc.)
 include 'secp-integration-test'  // Integration tests of API implementations (ffm and bouncy)
-// Skip this module on JDK 24 builds until all our CI can upgrade to JDK 25
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
-    include 'secp-examples-java'     // Java examples
-}
+include 'secp-examples-java'     // Java examples
 include 'secp-examples-kotlin'   // Kotlin examples
 


### PR DESCRIPTION
* gradle.properties: set javaToolchainVersion = 25
* settings.gradle: remove conditional for Java 25
* flake.nix: replace JDK 24 with graalvm 25, use nxpkgs-jdk-ea 25
* GHA gradle.yml: remove -PjavaToolchainVersion override
* .gitlab-ci.yml: remove -PjavaToolchainVersion override

Note that the changes in `flake.nix` switch from nixpkgs-unstable to nixpkgs-jdk-ea/nixpkgs/jdk-ea-25, which is a fork of nixpkgs that is nixpkgs/master + https://github.com/NixOS/nixpkgs/pull/434086

It is maintained by @msgilligan and nixpkgs/master is periodically merged in. Once Gradle 9.1.0 is final, we can immediately switch to nixpkgs/master and a few days later back to nixpkgs-unstable.

After this is merged PR #206 can be rebased.