### PR TITLE
flake.nix: set nixpkgs.url to nixos/nixpkgs/master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758235692,
-        "narHash": "sha256-+c7i+7SaAOGUUBYq64U4SX3Ta3K881IrcyGan4jsS+Q=",
-        "owner": "nixpkgs-jdk-ea",
+        "lastModified": 1758289101,
+        "narHash": "sha256-dDSAXmE+JOUo3gcdH6lxnVJSQ7d791vrVzFCGC2w4So=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1f4b46036a79e085e863ce1aa904810acf75362c",
+        "rev": "43e96b5b653685e2ec13a6b047ec1a7f2a42faf9",
         "type": "github"
       },
       "original": {
-        "owner": "nixpkgs-jdk-ea",
-        "ref": "jdk-ea-25",
+        "owner": "nixos",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "secp2565k1-jdk (Java API & implementations for secp256k1)";
 
   inputs = {
-    nixpkgs.url = "github:nixpkgs-jdk-ea/nixpkgs/jdk-ea-25";
+    nixpkgs.url = "github:nixos/nixpkgs/master";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";


### PR DESCRIPTION
Gradle 9.1 is available on nixpkgs/master (see https://github.com/NixOS/nixpkgs/pull/434086) so let's switch back to `nixos/nixpkgs/master`.

Once Gradle 9.1 hits `nixpkgs-unstable`, we can move back to that branch.