### PR TITLE
secp-examples-java/build.gradle: applicationName = 'schnorr-example'

### DIFF
--- a/secp-examples-java/build.gradle
+++ b/secp-examples-java/build.gradle
@@ -27,6 +27,7 @@ jar {
 application {
     mainModule = 'org.bitcoinj.secp.examples'
     mainClass = 'org.bitcoinj.secp.examples.Schnorr'
+    applicationName = 'schnorr-example'
 }
 
 run {


### PR DESCRIPTION
This changes the name of the script generated by the `:installDist` task to match the name of the native-image binary.

(The README will be updated in a separate PR)
