### PR TITLE
flake.lock: nix flake update (gradle 9.1.0-rc-3)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757000898,
-        "narHash": "sha256-6HbDHFltcXtx2LJ5kesNMuO0185Lkev0LvW1rEjbuP4=",
+        "lastModified": 1757445992,
+        "narHash": "sha256-bLdIfrOEJOhcxPfvERj9tkL+7u6TT+G843xpTXd2j4U=",
         "owner": "nixpkgs-jdk-ea",
         "repo": "nixpkgs",
-        "rev": "6c59b63c0f95e847a81028bbd7329adc22ba55ef",
+        "rev": "86b0cae70e2c9a3d7f210f8b853b2b7158dff0b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This commit was produced by running `nix flake update` to update to the latest commit on the `nixpkgs-jdk-ea/nixpkgs/jdk-ea-25` branch. 