### PR TITLE
secp-ffm/build.gradle: fix moduleName o.b.secp.ffm

### DIFF
--- a/secp-ffm/build.gradle
+++ b/secp-ffm/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-ext.moduleName = 'org.bitcoinj.secp256k1.ffm'
+ext.moduleName = 'org.bitcoinj.secp.ffm'
 
 dependencies {
     api project(':secp-api')


### PR DESCRIPTION
The moduleName for the secp-ffm was incorrect/inconsistent. Rename to org.bitcoinj.secp.ffm from org.bitcoinj.secp256k1.ffm