### PR TITLE
flake.lock: nix flake update (gradle 9.1.0-rc-4)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757445992,
-        "narHash": "sha256-bLdIfrOEJOhcxPfvERj9tkL+7u6TT+G843xpTXd2j4U=",
+        "lastModified": 1757980160,
+        "narHash": "sha256-gMTbtp1qXteN7WWGalJenzsq/YydzCH9e9xrrOa8B08=",
         "owner": "nixpkgs-jdk-ea",
         "repo": "nixpkgs",
-        "rev": "86b0cae70e2c9a3d7f210f8b853b2b7158dff0b9",
+        "rev": "e9c8ac3ef4f3ff0b14e42a371260c100f92d1cdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This commit was produced by running `nix flake update` to update to the latest commit on the `nixpkgs-jdk-ea/nixpkgs/jdk-ea-25` branch.

Another way to (partially) verify this PR is to do the following:

Before checking out this branch:
```
$ nix develop        # or if you have direnv installed you can just hit <return>
$ which gradle
/nix/store/pgkppjl3am5wybncd043afnhfbbwp8ga-gradle-9.1.0-rc-3/bin/gradle
$ which java
/nix/store/m404l3x88m95h3lr1py0xnbzm76nqbba-graalvm-oracle-25-ea-36/bin/java
```
After checking out this branch:
```
$ nix develop        # or if you have direnv installed you can just hit <return>
$ which gradle
/nix/store/hbs94pjd1fzq4yj66sm5i09wk6d7hlra-gradle-9.1.0-rc-4/bin/gradle
$ which java
/nix/store/938i7rkhi8czr61lqs2kj56rlfmrz67f-graalvm-oracle-25-ea-36/bin/java
```

This shows that Gradle was updated, but `java` (GraalVM) was not.
