### PR TITLE
update to GraalVM 25 

### DIFF
--- a/.github/workflows/graal.yml
+++ b/.github/workflows/graal.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-14]
-        java: [ '25-ea' ]
+        java: [ '25' ]
         distribution: [ 'graalvm' ]
       fail-fast: false
     name: ${{ matrix.os }} ${{ matrix.java }} (via setup-graalvm)

--- a/README.adoc
+++ b/README.adoc
@@ -155,11 +155,11 @@ Run the script:
 
 * `./secp-examples-java/build/install/schnorr-example/bin/schnorr-example`
 
-==== Build and run a native image (Using GraalVM 25-ea)
+==== Build and run a native image (Using GraalVM 25)
 
 To build using GraalVM `native-image`:
 
-. Make sure you have GraalVM 25 (EA 31) or later installed
+. Make sure you have GraalVM 25 or later installed
 . Make sure `GRAALVM_HOME` points to the Graal JDK 25 installation
 . `./gradlew secp-examples-java:nativeCompile`
 

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757980160,
-        "narHash": "sha256-gMTbtp1qXteN7WWGalJenzsq/YydzCH9e9xrrOa8B08=",
+        "lastModified": 1758049296,
+        "narHash": "sha256-4F2whTRQhY2L+7KPArG+s9FF2wUbf56OKVgdSaMXQQY=",
         "owner": "nixpkgs-jdk-ea",
         "repo": "nixpkgs",
-        "rev": "e9c8ac3ef4f3ff0b14e42a371260c100f92d1cdf",
+        "rev": "45abac2e882dda93a1027e04b13b6a5a09ad80ff",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           config.allowUnfreePredicate = pkg:
             builtins.elem (pkgs.lib.getName pkg) allowedUnfree;
         };
-        graalvm = pkgs.graalvmPackages.graalvm-oracle_25-ea;
+        graalvm = pkgs.graalvmPackages.graalvm-oracle_25;
         sharedShellHook = ''
             if [[ "$(uname)" == "Darwin" ]]; then
               export DYLD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.secp256k1 ]}:$DYLD_LIBRARY_PATH"


### PR DESCRIPTION
* flake.nix: change graalvm package name to `_25` from `_25-ea`
* flake.lock: update to the latest nixpkgs-jdk-ea commit
* GHA graal.yml: Update to graalvm `25` from `25-ea`
* README.adoc: Changes to reflect use of GraalVM 25 GA

This is a child of PR #221 which applies a `nix flake update` that picked up Gradle 9.1.0-rc-4. It is not strictly necessary to apply that commit first, but it should be included for Git history purposes.