### PR TITLE
GHA gradle.yml: update to JDK 25 (GA)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           # When installing multiple JDKs, the last JDK installed is the default and will be used to run Gradle itself
           java-version: |
-            25-ea
+            25
           cache: 'gradle'
       - name: Install secp256k1 with APT
         if: runner.os == 'Linux'


### PR DESCRIPTION
~~This is _DRAFT_ because JDK 25 for `aarch64-linux` is not available on GHA yet.~~
