### PR TITLE
flake.nix: replace flake-parts input with forEachSystem function

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1758416067,
@@ -38,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }


### PR DESCRIPTION
Reduce our Flake inputs (dependencies) to just `nixpkgs` by replacing the use of `flake-inputs` with a `forEachSystem` function.

This saves 1 line in `flake.nix` and 21 in `flake.lock`. But more importantly it eliminates a dependency that does "magic" with a simple function.
