### PR TITLE
secp-graalvm/build.gradle: Upgrade nativeimage JAR to 25.0.0

### DIFF
--- a/secp-graalvm/build.gradle
+++ b/secp-graalvm/build.gradle
@@ -6,7 +6,7 @@ ext.moduleName = 'org.bitcoinj.secp.graalvm'
 
 dependencies {
     api("org.jspecify:jspecify:1.0.0")
-    implementation 'org.graalvm.sdk:nativeimage:24.2.2'
+    implementation 'org.graalvm.sdk:nativeimage:25.0.0'
 }
 
 jar {

--- a/secp-graalvm/build.gradle
+++ b/secp-graalvm/build.gradle
@@ -6,7 +6,7 @@ ext.moduleName = 'org.bitcoinj.secp.graalvm'
 
 dependencies {
     api("org.jspecify:jspecify:1.0.0")
-    implementation group: 'org.graalvm.sdk', name: 'nativeimage', version: '24.2.2'
+    implementation 'org.graalvm.sdk:nativeimage:24.2.2'
 }
 
 jar {


### PR DESCRIPTION
There is also a related commit that changes the syntax of the `implementation` declaration for `nativeimage` to the standard (and Gradle 10 compatible) format.