### PR TITLE
README: Update now that JDK 25 is available everywhere

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@ image::https://img.shields.io/badge/Matrix%20Chat-Join%20secp256k1--jdk--develop
 `secp256k1-jdk` is a Java library providing Bitcoin-related Elliptic Curve Cryptography functions using the https://www.secg.org/[SECG] curve
 https://en.bitcoin.it/wiki/Secp256k1[secp256k1]. It provides both ECDSA and Schnorr message signing functions.
 
-It provides a Java API that enables multiple implementations. The proof-of-concept includes an implementation that adapts https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1], a native C
+It provides a Java API that enables multiple implementations. The proof-of-concept includes an implementation that adapts https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1], a high-quality, native C
 library implementing elliptic curve operations on the secp256k1 curve. We also plan to provide an implementation using the popular https://www.bouncycastle.org[Bouncy Castle] library.
 
 The library supports other JDK-based languages such as Kotlin, Groovy, Scala, and Clojure (as these languages can all use Java classes directly.) In the future, we may provide documentation, examples, and language-specific extensions for one or more additional JVM languages. (Kotlin examples are in-progress.)
@@ -20,30 +20,30 @@ WARNING:: This prototype software has had limited testing and has not been revie
 The API is based on the `C-language` API of https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1], but adapted
 to modern, idiomatic, functional-style Java and to use Elliptic Curve types from the Java Class Library, such as https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/interfaces/ECPublicKey.html[ECPublicKey] where appropriate.
 
-The API is distributed as an API-only JAR (```secp-api-_version_.jar```) and we expect that there will be multiple implementations of the API. The API JAR currently requires JDK 9 or later but we may backport it to JDK 8 in a future release depending upon feedback from the community.
+The API is distributed as an API-only JAR (```secp-api-_version_.jar```) and there will be multiple implementations of the API. The API JAR currently requires JDK 9 or later but we may backport it to JDK 8 in a future release depending upon feedback from the community.
 
 NOTE:: At this point, we are especially interested in feedback on the API.
 
-== libsecp256k1 Panama Implementation (JDK 24+)
+== libsecp256k1 FFM ("Panama") Implementation (JDK 24+)
 
 The provided proof-of-concept implementation uses the https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1] C-language library via https://openjdk.org/jeps/454[JEP-454: Foreign Function & Memory API] (known as **Panama**.) It is provided in a separate JAR (```secp-ffm-_version_.jar```) that requires JDK 24 or later.
 
 Panama was released as part of https://openjdk.org/projects/jdk/22/[OpenJDK 22]. We anticipate `secp-ffm` will be
 the recommended/preferred `secp-api` implementation for use in projects using modern JVMs.
 
-The minimum required JDK for the `secp-ffm` module will be incremented to JDK 25 (the next LTS release of the JDK) before the 1.0 release of `secp256k1-jdk`.
+The minimum required JDK for the `secp-ffm` module will be increased to JDK 25 (the first LTS release with FFM included) before the 1.0 release of `secp256k1-jdk`.
 
 WARNING:: This is a preliminary implementation provided for experimentation and feedback and should not be used in real applications.
 
 == Bouncy Castle Implementation
 
-An incomplete https://www.bouncycastle.org[Bouncy Castle]-based submodule is included. Bouncy Castle is a well-regarded cryptography library that includes support for the secp256k1 curve and is currently used by https://bitcoinj.org[bitcoinj] and other Java-based Bitcoin implementations. We expect this implementation to be completed and made available as a pure-Java implementation for those who are unable to use the native libsecp256k1 implementation and/or Panama.
+An incomplete https://www.bouncycastle.org[Bouncy Castle]-based submodule is included. Bouncy Castle is a well-regarded cryptography library that includes support for the secp256k1 curve and is currently used by https://bitcoinj.org[bitcoinj] and other Java-based Bitcoin implementations. We expect this implementation to be completed and made available as a pure-Java implementation for those who are unable to use the FFM-based libsecp256k1 implementation.
 
 The Bouncy Castle implementation is currently targeting JDK 9, but if the API is backported to JDK 8, so will the Bouncy Castle implementation.
 
 == libsecp256k1 Implementation for older JDKs
 
-There are currently _no plans_ for an implementation using earlier Java-to-C adapter technologies such as https://docs.oracle.com/en/java/javase/21/docs/specs/jni/index.html[JNI] or https://github.com/java-native-access/jna[JNA]. However, the `secp256k1-jdk` API should support such an implementation. We would be supportive if someone in the community endeavours to create an implementation or adapt one of the existing implementations to use the `secp256k1-jdk` API.
+There are currently _no plans_ for an implementation using earlier Java-to-C adapter technologies such as https://docs.oracle.com/en/java/javase/21/docs/specs/jni/index.html[JNI] or https://github.com/java-native-access/jna[JNA]. However, the `secp256k1-jdk` API will support a JNI implementation. We would be supportive if someone in the community endeavours to create an implementation or adapt one of the existing implementations to use the `secp256k1-jdk` API.
 
 == Relation to bitcoinj
 
@@ -67,11 +67,11 @@ The build requires JDK 25. Gradle 9.1.0 or later is required and is provided by 
 
 === Installing OpenJDK 25 or GraalVM JDK 25
 
-The `nativeCompile` Gradle task uses `$GRAALVM_HOME` to find the `native-image` binary. The Nix devShell sets this up automatically, but if you install GraalVM using one of the other mechanisms verify `GRAALVM_HOME` is set correctly.
+The `nativeCompile` Gradle task uses `$GRAALVM_HOME` to find the `native-image` binary. The Nix devShell sets this up automatically. If you install GraalVM using one of the other mechanisms, you should verify that `GRAALVM_HOME` is set correctly.
 
 ==== Using the Nix devShell
 
-When using the Nix devShell, GraalVM JDK 25 is installed automatically.
+When using the Nix devShell, JDK 25 is installed automatically.
 
 ==== Using APT
 
@@ -81,17 +81,17 @@ There is no APT package for GraalVM, see https://www.graalvm.org/downloads/[Graa
 
 ==== Using SDKMAN!
 
-SDKMAN! currently has early access (release candidate) builds of both OpenJDK and GraalVM available.
+SDKMAN! provides JDK 25 in both _Temurin_ and _GraalVM Community Edition_ flavors (among others).
 
-* `sdk install java 25.ea.36-open`
+* `sdk install java 25-tem`
 
 or for GraalVM builds:
 
-* `sdk install java 25.ea.36-graal`
+* `sdk install java 25-graalce`
 
 ==== Using Homebrew
 
-Note: Homebrew does not have OpenJDK 25 or GraalVM JDK 25 yet, but when it is updated you can try:
+Note: Homebrew provides both OpenJDK 25 and GraalVM JDK 25.
 
 * `brew install openjdk`
 


### PR DESCRIPTION
Bring the README up-to-date:

* JDK 25 and GraalVM CE 25 are in SDKMAN! and Homebrew now
* Clarification and/or simplification in a few places