### PR TITLE
gradle.properties: configuration-cache=false

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,5 @@ org.gradle.java.installations.auto-detect = true
 # JDK early access versions and Gradle just reports errors when trying to download them.
 org.gradle.java.installations.auto-download = false
 
+# stop nagging about the configuration cache
+org.gradle.configuration-cache = false


### PR DESCRIPTION
This turns off nagging about enabling the configuration cache.