### PR TITLE
GHA gradle.yml: Add Print Sha256Sums steps

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,12 @@ jobs:
         run: ./gradlew build
       - name: Run Java & Kotlin Examples
         run: ./gradlew run runEcdsa
+      - name: Print Sha256Sums (Linux)
+        if: runner.os == 'Linux'
+        run: sha256sum secp-api/build/libs/* secp-bouncy/build/libs/* secp-ffm/build/libs/* secp-graalvm/build/libs/*
+      - name: Print Sha256Sums (macOS)
+        if: runner.os == 'macOS'
+        run: shasum -a 256 secp-api/build/libs/* secp-bouncy/build/libs/* secp-ffm/build/libs/* secp-graalvm/build/libs/*
 
 
   build_nix:
@@ -63,3 +69,9 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build in Nix development shell
         run: nix develop -c gradle build run runEcdsa
+      - name: Print Sha256Sums (Linux)
+        if: runner.os == 'Linux'
+        run: sha256sum secp-api/build/libs/* secp-bouncy/build/libs/* secp-ffm/build/libs/* secp-graalvm/build/libs/*
+      - name: Print Sha256Sums (macOS)
+        if: runner.os == 'macOS'
+        run: shasum -a 256 secp-api/build/libs/* secp-bouncy/build/libs/* secp-ffm/build/libs/* secp-graalvm/build/libs/*

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 // Projects to be published with maven-publish
-ext.publishedProjects = ['secp-api', 'secp-ffm', 'secp-bouncy']
+ext.publishedProjects = ['secp-api', 'secp-ffm', 'secp-bouncy', 'secp-graalvm']
 
 subprojects { sub ->
     apply plugin: 'java'


### PR DESCRIPTION
The first commit adds the `secp-graalvm` "helper" JAR to the list of of published sub-projects.
