### PR TITLE
WIP: support a jlink'ed schnorr-example

### DIFF
--- a/secp-examples-java/build.gradle
+++ b/secp-examples-java/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'application'
+    id 'org.beryx.jlink'    version '3.1.4-rc'
 }
 
 ext.moduleName = 'org.bitcoinj.secp.examples'
@@ -39,6 +40,13 @@ run {
 configurations {
     nativeToolImplementation.extendsFrom implementation
     nativeToolRuntimeOnly.extendsFrom runtimeOnly
+}
+
+jlink {
+    options = ['--add-modules', 'org.bitcoinj.secp.ffm']
+    launcher {
+        name = application.applicationName
+    }
 }
 
 tasks.register('runEcdsa', JavaExec) {


### PR DESCRIPTION
This works on macOS if `gradle jlink` is followed by:

```
cp /nix/store/<hash>-secp256k1-0.6.0/lib/libsecp256k1.* secp-examples-java/build/image/lib/
```

So either the library copy needs to be added to the build or the native code needs to be bundled in the module/jar -- I need to research this a little further.