### PR TITLE
WIP: Add custom jlink/jshell example

### DIFF
--- a/secp-examples-jshell/build.gradle
+++ b/secp-examples-jshell/build.gradle
@@ -1,0 +1,83 @@
+import org.codehaus.groovy.runtime.GStringImpl
+
+plugins {
+    id 'java'
+    id 'application'
+    id 'org.beryx.jlink'    version '3.1.4-rc'
+}
+
+ext.moduleName = 'org.bitcoinj.secp.jshell'
+ext.libSecpDir = System.getenv("LIBSECP_DIR")
+ext.javaHome = System.getenv("JAVA_HOME")
+
+dependencies {
+    implementation project(':secp-api')
+    implementation project(':secp-bouncy')
+    implementation project(':secp-ffm')
+}
+
+tasks.withType(JavaCompile).configureEach {
+    // Override Default release version
+    options.release = 25
+}
+
+jar {
+    inputs.property("moduleName", moduleName)
+    manifest {
+        attributes  'Implementation-Title': 'Placeholder App for secp256k1-jdk JShell Example',
+                'Main-Class': application.mainClass,
+                'Implementation-Version': archiveVersion.get()
+    }
+}
+
+application {
+    mainModule = 'org.bitcoinj.secp.jshell'
+    mainClass = 'org.bitcoinj.secp.jshell.Hello'
+    applicationName = 'hello'
+}
+
+run {
+    jvmArgs += '--enable-native-access=org.bitcoinj.secp.ffm'
+}
+
+jlink {
+    options = ['--add-modules', 'org.bitcoinj.secp.ffm',
+               '--add-modules', 'org.bitcoinj.secp.bouncy', '--ignore-signing-information',
+               '--add-modules', 'jdk.jshell']
+    launcher {
+        name = application.applicationName
+    }
+}
+
+tasks.register('copyNativeLibraries', Copy) {
+    dependsOn tasks.jlink
+    from(libSecpDir) { include 'libsecp256k1.*' }
+    into("${tasks.jlink.imageDir}/lib")
+}
+
+tasks.register('copyJdkSource', Copy) {
+    dependsOn tasks.jlink
+    from {
+        def javaHome = System.getenv('JAVA_HOME') ?: System.getProperty('java.home')
+        file("$javaHome/lib/src.zip")
+    }
+    into("${tasks.jlink.imageDir}/lib")
+    finalizedBy(tasks.named('addJshellWrapper'))
+}
+
+tasks.register('addJshellWrapper') {
+    dependsOn tasks.copyJdkSource
+    doLast {
+        def jshellScript = file("${tasks.jlink.imageDir}/bin/secp-shell")
+        jshellScript.text = """#!/bin/bash
+DIR=\$(dirname "\$0")
+"\$DIR/jshell" "\$@"
+"""
+        jshellScript.setExecutable(true)
+    }
+}
+
+tasks.jlink {
+    finalizedBy(tasks.copyNativeLibraries, tasks.copyJdkSource) // tasks.copyProjectJavadoc
+}
+

--- a/secp-examples-jshell/src/main/java/module-info.java
+++ b/secp-examples-jshell/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * JShell Example.
+ */
+module org.bitcoinj.secp.jshell {
+    requires org.bitcoinj.secp;
+}

--- a/secp-examples-jshell/src/main/java/org/bitcoinj/secp/jshell/Hello.java
+++ b/secp-examples-jshell/src/main/java/org/bitcoinj/secp/jshell/Hello.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.jshell;
+
+public class Hello {
+    void main() {
+        IO.println("Hello! Try running the `secp-shell` executable for JShell with secp256k1-jdk built-in.");
+    }
+}

--- a/secp-examples-jshell/src/main/java/org/bitcoinj/secp/jshell/package-info.java
+++ b/secp-examples-jshell/src/main/java/org/bitcoinj/secp/jshell/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// Contains a placeholder application for a custom JShell build.
+package org.bitcoinj.secp.jshell;

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,5 +7,6 @@ include 'secp-graalvm'           // GraalVM Foreign Function Registration suppor
 include 'secp-bitcoinj'          // bitcoinj integration utilities and tests (P2TR address generation, etc.)
 include 'secp-integration-test'  // Integration tests of API implementations (ffm and bouncy)
 include 'secp-examples-java'     // Java examples
+include 'secp-examples-jshell'   // jshell example
 include 'secp-examples-kotlin'   // Kotlin examples
 


### PR DESCRIPTION
This is WIP, but `gradle secp-examples-jshell:jlink` should build an image with a jshell that contains
libsecp256k1 and supports the following (for example)

import org.bitcoinj.secp.api.*
var secp = Secp256k1.get()

This will load the FFM implementation.

Issues:

* The `gradle secp-examples-jshell:jlink` target depends on the `LIBSECP_DIR` which is currently only set up in the Nix devShell.
* I haven't tried building under CI or on platforms other than macOS
* I'm not sure if the copyJdkSource task is working properly
* I haven't figured out how to get secp-api source configured in `jshell` (if possible)