### PR TITLE
Secp256k1: Use id libsecp256k1-ffm for secp-ffm

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -87,7 +87,7 @@ public interface Secp256k1 extends Closeable {
      */
     enum ProviderId {
         /** libsecp256k1 'C" library accessed through Java FFM */
-        LIBSECP256K1_FFM("ffm"),
+        LIBSECP256K1_FFM("libsecp256k1-ffm"),
         /** Bouncy Castle library */
         BOUNCY_CASTLE("bouncy-castle");
 


### PR DESCRIPTION
Make the `id` for the `secp-ffm` module a little more descriptive.  (When we get a JNI implementation it can be `libsecp256k1-jni`)