### PR TITLE
EcdhSharedSecret,EcdhSharedSecretImpl: create types for ECDH shared secret

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/EcdhSharedSecret.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/EcdhSharedSecret.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp;
+
+/**
+ * An secp256k1 ECDH shared secret (a 32-byte hash.)
+ */
+public interface EcdhSharedSecret extends ByteArray {
+}

--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -256,7 +256,7 @@ public interface Secp256k1 extends Closeable {
      * @param secKey secret key
      * @return ecdh key agreement
      */
-    Result<byte[]> ecdh(P256k1PubKey pubKey, P256k1PrivKey secKey);
+    Result<EcdhSharedSecret> ecdh(P256k1PubKey pubKey, P256k1PrivKey secKey);
 
     /**
      * Override close and declare that no checked exceptions are thrown

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdhSharedSecretImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdhSharedSecretImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.internal;
+
+import org.bitcoinj.secp.ByteArray;
+import org.bitcoinj.secp.EcdhSharedSecret;
+
+import java.util.Arrays;
+
+/**
+ * A secp256k1 ECDH shared secret, stored as a {@link ByteArray}.
+ */
+public class EcdhSharedSecretImpl  implements EcdhSharedSecret {
+    private final byte[] bytes;
+
+    public EcdhSharedSecretImpl(byte[] bytes) {
+        this.bytes = Arrays.copyOf(bytes, bytes.length);
+    }
+
+    @Override
+    public byte[] bytes() {
+        return Arrays.copyOf(bytes, bytes.length);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bytes());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof EcdhSharedSecretImpl && Arrays.equals(bytes(), ((EcdhSharedSecretImpl) o).bytes());
+    }
+}

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -15,6 +15,7 @@
  */
 package org.bitcoinj.secp.bouncy;
 
+import org.bitcoinj.secp.EcdhSharedSecret;
 import org.bitcoinj.secp.P256K1FieldElement;
 import org.bitcoinj.secp.P256K1KeyPair;
 import org.bitcoinj.secp.P256K1XOnlyPubKey;
@@ -24,6 +25,7 @@ import org.bitcoinj.secp.Result;
 import org.bitcoinj.secp.SchnorrSignature;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.P256K1KeyPairImpl;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
@@ -204,11 +206,11 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public Result<byte[]> ecdh(P256k1PubKey pubKey, P256k1PrivKey secKey) {
+    public Result<EcdhSharedSecret> ecdh(P256k1PubKey pubKey, P256k1PrivKey secKey) {
         ECPoint point = BC.fromECPoint(pubKey.getW());
         ECPoint ssPoint = point.multiply(secKey.getS()).normalize();
         byte[] hashed = ecdhHash(BC.toP256K1PubKey(ssPoint));
-        return Result.ok(hashed);
+        return Result.ok(new EcdhSharedSecretImpl(hashed));
     }
     
     private byte[] ecdhHash(P256k1PubKey sspk) {

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -16,6 +16,7 @@
 package org.bitcoinj.secp.ffm;
 
 import org.bitcoinj.secp.ByteArray;
+import org.bitcoinj.secp.EcdhSharedSecret;
 import org.bitcoinj.secp.P256K1FieldElement;
 import org.bitcoinj.secp.P256K1KeyPair;
 import org.bitcoinj.secp.P256K1XOnlyPubKey;
@@ -25,6 +26,7 @@ import org.bitcoinj.secp.Result;
 import org.bitcoinj.secp.SchnorrSignature;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.P256K1KeyPairImpl;
 import org.bitcoinj.secp.internal.P256k1PubKeyImpl;
 import org.bitcoinj.secp.ffm.jextract.secp256k1_ecdsa_signature;
@@ -383,13 +385,13 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     @Override
-    public Result<byte[]> ecdh(P256k1PubKey pubKey, P256k1PrivKey secKey) {
+    public Result<EcdhSharedSecret> ecdh(P256k1PubKey pubKey, P256k1PrivKey secKey) {
         MemorySegment pubKeySeg = pubKeyParse(pubKey);  // Get pubkey in 64-byte internal format
         MemorySegment secKeySeg = arena.allocateFrom(JAVA_BYTE, secKey.getEncoded());
         MemorySegment output = arena.allocate(32);
         int success = secp256k1_h.secp256k1_ecdh(ctx, output, pubKeySeg, secKeySeg, NULL(), NULL());
         return success == 1
-                ? Result.ok(output.toArray(JAVA_BYTE))
+                ? Result.ok(new EcdhSharedSecretImpl(output.toArray(JAVA_BYTE)))
                 : Result.err(-1);
     }
 

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdhTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdhTest.java
@@ -15,6 +15,7 @@
  */
 package org.bitcoinj.secp.integration;
 
+import org.bitcoinj.secp.EcdhSharedSecret;
 import org.bitcoinj.secp.P256k1PrivKey;
 import org.bitcoinj.secp.P256k1PubKey;
 import org.bitcoinj.secp.Result;
@@ -33,10 +34,10 @@ public class EcdhTest {
         try (Secp256k1 secp = new Secp256k1Foreign()) {
             P256k1PrivKey secKey = P256k1PrivKey.of(BigInteger.ONE);
             P256k1PubKey pubKey = secp.ecPubKeyCreate(secKey);
-            Result<byte[]> result = secp.ecdh(pubKey, secKey);
+            Result<EcdhSharedSecret> result = secp.ecdh(pubKey, secKey);
             Assertions.assertNotNull(result);
             Assertions.assertInstanceOf(Result.Ok.class, result);
-            Assertions.assertEquals(32, result.get().length);
+            Assertions.assertEquals(32, result.get().bytes().length);
         }
     }
 
@@ -50,19 +51,19 @@ public class EcdhTest {
             P256k1PubKey pubKey2 = secp.ecPubKeyCreate(secKey2);
 
             // Compute shared secret with secKey1
-            Result<byte[]> result1 = secp.ecdh(pubKey2, secKey1);
+            Result<EcdhSharedSecret> result1 = secp.ecdh(pubKey2, secKey1);
             Assertions.assertNotNull(result1);
             Assertions.assertInstanceOf(Result.Ok.class, result1);
-            Assertions.assertEquals(32, result1.get().length);
+            Assertions.assertEquals(32, result1.get().bytes().length);
 
             // Compute shared secret with secKey2
-            Result<byte[]> result2 = secp.ecdh(pubKey1, secKey2);
+            Result<EcdhSharedSecret> result2 = secp.ecdh(pubKey1, secKey2);
             Assertions.assertNotNull(result1);
             Assertions.assertInstanceOf(Result.Ok.class, result2);
-            Assertions.assertEquals(32, result2.get().length);
+            Assertions.assertEquals(32, result2.get().bytes().length);
 
             // The separately computed shared secrets should be equal
-            Assertions.assertArrayEquals(result1.get(), result2.get());
+            Assertions.assertEquals(result1.get(), result2.get());
         }
     }
 
@@ -71,10 +72,10 @@ public class EcdhTest {
         try (Secp256k1 secp = new Bouncy256k1()) {
             P256k1PrivKey secKey = P256k1PrivKey.of(BigInteger.ONE);
             P256k1PubKey pubKey = secp.ecPubKeyCreate(secKey);
-            Result<byte[]> result = secp.ecdh(pubKey, secKey);
+            Result<EcdhSharedSecret> result = secp.ecdh(pubKey, secKey);
             Assertions.assertNotNull(result);
             Assertions.assertInstanceOf(Result.Ok.class, result);
-            Assertions.assertEquals(32, result.get().length);
+            Assertions.assertEquals(32, result.get().bytes().length);
         }
     }
 
@@ -88,19 +89,19 @@ public class EcdhTest {
             P256k1PubKey pubKey2 = secp.ecPubKeyCreate(secKey2);
 
             // Compute shared secret with secKey1
-            Result<byte[]> result1 = secp.ecdh(pubKey2, secKey1);
+            Result<EcdhSharedSecret> result1 = secp.ecdh(pubKey2, secKey1);
             Assertions.assertNotNull(result1);
             Assertions.assertInstanceOf(Result.Ok.class, result1);
-            Assertions.assertEquals(32, result1.get().length);
+            Assertions.assertEquals(32, result1.get().bytes().length);
 
             // Compute shared secret with secKey2
-            Result<byte[]> result2 = secp.ecdh(pubKey1, secKey2);
+            Result<EcdhSharedSecret> result2 = secp.ecdh(pubKey1, secKey2);
             Assertions.assertNotNull(result1);
             Assertions.assertInstanceOf(Result.Ok.class, result2);
-            Assertions.assertEquals(32, result2.get().length);
+            Assertions.assertEquals(32, result2.get().bytes().length);
 
             // The separately computed shared secrets should be equal
-            Assertions.assertArrayEquals(result1.get(), result2.get());
+            Assertions.assertEquals(result1.get(), result2.get());
         }
     }
 
@@ -109,9 +110,9 @@ public class EcdhTest {
         try (Secp256k1Foreign secp1 = new Secp256k1Foreign(); Bouncy256k1 secp2 = new Bouncy256k1()) {
             P256k1PrivKey secKey = P256k1PrivKey.of(BigInteger.ONE);
             P256k1PubKey pubKey = secp1.ecPubKeyCreate(secKey);
-            Result<byte[]> result1 = secp1.ecdh(pubKey, secKey);
-            Result<byte[]> result2 = secp2.ecdh(pubKey, secKey);
-            Assertions.assertArrayEquals(result1.get(), result2.get());
+            Result<EcdhSharedSecret> result1 = secp1.ecdh(pubKey, secKey);
+            Result<EcdhSharedSecret> result2 = secp2.ecdh(pubKey, secKey);
+            Assertions.assertEquals(result1.get(), result2.get());
         }
     }
 
@@ -125,19 +126,19 @@ public class EcdhTest {
             P256k1PubKey pubKey2 = secp2.ecPubKeyCreate(secKey2);
 
             // Compute shared secret with secKey1 and secp1 (implementation 1)
-            Result<byte[]> result1 = secp1.ecdh(pubKey2, secKey1);
+            Result<EcdhSharedSecret> result1 = secp1.ecdh(pubKey2, secKey1);
             Assertions.assertNotNull(result1);
             Assertions.assertInstanceOf(Result.Ok.class, result1);
-            Assertions.assertEquals(32, result1.get().length);
+            Assertions.assertEquals(32, result1.get().bytes().length);
 
             // Compute shared secret with secKey2 and secp2 (implementation 2)
-            Result<byte[]> result2 = secp2.ecdh(pubKey1, secKey2);
+            Result<EcdhSharedSecret> result2 = secp2.ecdh(pubKey1, secKey2);
             Assertions.assertNotNull(result1);
             Assertions.assertInstanceOf(Result.Ok.class, result2);
-            Assertions.assertEquals(32, result2.get().length);
+            Assertions.assertEquals(32, result2.get().bytes().length);
 
             // The separately computed shared secrets should be equal
-            Assertions.assertArrayEquals(result1.get(), result2.get());
+            Assertions.assertEquals(result1.get(), result2.get());
         }
     }
 }


### PR DESCRIPTION
These types make the API more type-safe and consistent and also allow
for possible future implementations with alternative data storage
(e.g. MemorySegment.)

~~Child of PR #255~~ Rebased. 