### PR TITLE
Cleanup serialization, toString(), use P256K1PointUncompressed internal to P256k1PubKeyImpl

### DIFF
--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
@@ -42,7 +42,7 @@ public class Ecdsa {
             P256k1PubKey pubkey = secp.ecPubKeyCreate(privKey);
 
             /* Serialize the pubkey in a compressed form (33 bytes). */
-            byte[] compressedPubkey = secp.ecPubKeySerialize(pubkey, (int)2L /* secp256k1_h.SECP256K1_EC_COMPRESSED() */);
+            byte[] compressedPubkey = pubkey.serialize(true);
 
             /* === Signing === */
 

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
@@ -39,7 +39,7 @@ fun main() {
         val pubkey = secp.ecPubKeyCreate(privKey)
 
         /* Serialize the pubkey in a compressed form(33 bytes). */
-        val compressedPubkey = secp.ecPubKeySerialize(pubkey, 258 /* secp256k1_h.SECP256K1_EC_COMPRESSED() */)
+        val compressedPubkey = pubkey.serialize(true);
 
         /* === Signing === */
 


### PR DESCRIPTION
16 commits, mostly involved with serialization and toString(), but the switch to using P256K1PointUncompressed internal to P256k1PubKeyImpl is a significant enhancement as it uses our more "native" point type and eliminates conversions to and from BigInteger.

Update: 5 commits were approved and pushed to `master` -- 11 remaining.

Update: 7 more merged -- 4 remaining.

Update: All commits approved and merged except 426a848d8df7b9d0226b3808c2cd5461368d023b which is now in PR #265 (which should be merged after PR #264)