### PR TITLE
Ecdsa.java: Fix ecPubKeySerialize flags for compressed serialization

### DIFF
--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
@@ -42,7 +42,7 @@ public class Ecdsa {
             P256k1PubKey pubkey = secp.ecPubKeyCreate(privKey);
 
             /* Serialize the pubkey in a compressed form (33 bytes). */
-            byte[] compressedPubkey = secp.ecPubKeySerialize(pubkey, (int)2L /* secp256k1_h.SECP256K1_EC_COMPRESSED() */);
+            byte[] compressedPubkey = secp.ecPubKeySerialize(pubkey, 258 /* secp256k1_h.SECP256K1_EC_COMPRESSED() */);
 
             /* === Signing === */
 


### PR DESCRIPTION
Passing `2L` for flags is incorrect for compressed serialization. This commit changes the value to 258 to match Ecdsa.kt which works correctly. (Note that the serialization doesn't match the code comments, but it doesn't matter for operation of `Ecdsa.java` because the output is re-parsed by a method that will handle both compressed and uncompressed.

There is another pending PR (#265) that changes this to `pubkey.serialize(true)`, which is simple, not error-prone, less verbose, and idiomatic.

And Issue #263 will remind us to properly document and define constants for the `flags` parameter.