### PR TITLE
Ecdsa,Ecdsa.kt: use pubkey.serialize(true) for compressedPubKey

### DIFF
--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
@@ -42,7 +42,7 @@ public class Ecdsa {
             P256k1PubKey pubkey = secp.ecPubKeyCreate(privKey);
 
             /* Serialize the pubkey in a compressed form (33 bytes). */
-            byte[] compressedPubkey = secp.ecPubKeySerialize(pubkey, 258 /* secp256k1_h.SECP256K1_EC_COMPRESSED() */);
+            byte[] compressedPubkey = pubkey.serialize(true);
 
             /* === Signing === */
 

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
@@ -39,7 +39,7 @@ fun main() {
         val pubkey = secp.ecPubKeyCreate(privKey)
 
         /* Serialize the pubkey in a compressed form(33 bytes). */
-        val compressedPubkey = secp.ecPubKeySerialize(pubkey, 258 /* secp256k1_h.SECP256K1_EC_COMPRESSED() */)
+        val compressedPubkey = pubkey.serialize(true);
 
         /* === Signing === */
 


### PR DESCRIPTION
This is a child of PR #264 