### PR TITLE
GHA gradle.yml: 'JDK 25' not 'JDK 25-ea' in job name

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-14]
         distribution: ['temurin']
       fail-fast: false
-    name: ${{ matrix.os }} JDK 25-ea (via Gradle Java toolchains)
+    name: ${{ matrix.os }} JDK 25 (via Gradle Java toolchains)
     steps:
       - name: Git checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
I missed this when I bumped the version used by the setup-java action.