### PR TITLE
Kotlin examples: Upgrade to JDK 25 and Kotlin 2.3.0-Beta2

### DIFF
--- a/secp-examples-kotlin/build.gradle
+++ b/secp-examples-kotlin/build.gradle
@@ -11,9 +11,14 @@ dependencies {
     runtimeOnly project(':secp-ffm')
 }
 
+tasks.withType(JavaCompile).configureEach {
+    // Override Default release version
+    options.release = 25
+}
+
 kotlin {
     jvmToolchain(javaToolchainVersion as int)
-    compilerOptions.jvmTarget = JvmTarget.JVM_24
+    compilerOptions.jvmTarget = JvmTarget.JVM_25
 }
 
 application {


### PR DESCRIPTION
Since this is only two small example programs and nothing has a dependency on this module, I think we should upgrade to Kotlin 2.3.0 even though it is still in Beta. This makes us ready to upgrade all modules using secp-ffm to JDK 25 as soon as we are ready.

(I'm not sure when we will be ready to bump all FFM-dependent modules to JDK 25. I'll want a go-ahead from @craigraw and I think we should wait until at least the 0.3 release.)
