### PR TITLE
Misc improvements in preparation for Low-R grinding

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
@@ -34,6 +34,13 @@ public interface EcdsaSignature extends ByteArray {
     SecpFieldElement s();
 
     /**
+     * Is this signature a "low R" signature.
+     * In other words: In a 256-bit big-endian representation of {@code R}, the high-bit is zero.
+     * @return true if this signature has a <i>low R</i> value.
+     */
+    boolean hasLowR();
+
+    /**
      * Create an ECDSA signature from serialized bytes
      * @param bytes bytes
      * @return signature

--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -75,6 +75,12 @@ public interface Secp256k1 extends Closeable {
         1);             // Cofactor h
 
     /**
+     * Equal to {@code EC_PARAMS.getOrder().shiftRight(1)}, used for canonicalizing the S value of a signature. If you aren't
+     * sure what this is about, you can ignore it.
+     */
+    SecpFieldElement HALF_CURVE_ORDER = SecpFieldElement.of(EC_PARAMS.getOrder().shiftRight(1));
+
+    /**
      * Get a stream of all known providers
      * @return stream of all known providers
      */

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpResult.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpResult.java
@@ -73,6 +73,14 @@ public /* sealed */ interface SecpResult<T> {
     }
 
     /**
+     * Is the result successful ({@link Ok})?
+     * @return true if result is {@code instanceof} {@link Ok}
+     */
+    default boolean isOk() {
+        return this instanceof Ok;
+    }
+
+    /**
      * Static constructor for {@link SecpResult.Ok}
      * @param result result value
      * @return successful result

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
@@ -49,7 +49,13 @@ public class EcdsaSignatureImpl implements EcdsaSignature {
     public SecpFieldElement s() {
         return s;
     }
-    
+
+    @Override
+    public boolean hasLowR() {
+        // Is the high-bit of the first (high, big-endian) byte zero?
+        return this.r().serialize()[0] >= 0;
+    }
+
     @Override
     public byte[] bytes() {
         byte[] signature = new byte[64];

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpFieldElementImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpFieldElementImpl.java
@@ -24,10 +24,11 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- *
+ * Implementation of {@link SecpFieldElement} as an array of bytes.
  */
 public class SecpFieldElementImpl implements SecpFieldElement, ByteArray {
     static byte[] MAX_VALUE_BYTES = integerTo32Bytes(Secp256k1.P.subtract(BigInteger.ONE));
+    /** field element as a 32-byte big-endian byte array */
     private final byte[] value;
 
     public SecpFieldElementImpl(BigInteger i) {
@@ -96,8 +97,8 @@ public class SecpFieldElementImpl implements SecpFieldElement, ByteArray {
      * Throw {@link IllegalArgumentException} if the byte array is not the length.
      * <p>
      * <b>NOTE:</b> We are not currently validating for value less than {@code P}
-     * @param e unvalidated integer
-     * @return a validated integer
+     * @param e unvalidated integer ({@code byte[]} format)
+     * @return a validated integer ({@code byte[]} format)
      */
     public static byte[] checkInRange(byte[] e) {
         if (e.length != 32) {

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpFieldElementImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpFieldElementImpl.java
@@ -18,6 +18,7 @@ package org.bitcoinj.secp.internal;
 import org.bitcoinj.secp.ByteArray;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.SecpFieldElement;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -55,7 +56,7 @@ public class SecpFieldElementImpl implements SecpFieldElement, ByteArray {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         SecpFieldElementImpl that = (SecpFieldElementImpl) o;
         return Objects.deepEquals(value, that.value);

--- a/secp-api/src/test/java/org/bitcoinj/secp/P256K1FieldElementTest.java
+++ b/secp-api/src/test/java/org/bitcoinj/secp/P256K1FieldElementTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for P256K1FieldElementTest
+ * Tests for P256K1FieldElement
  */
 public class P256K1FieldElementTest {
     static BigInteger p = Secp256k1.P;

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -60,7 +60,7 @@ public class Bouncy256k1 implements Secp256k1 {
     static final ECDomainParameters BC_CURVE;
 
     /**
-     * Equal to CURVE.getN().shiftRight(1), used for canonicalising the S value of a signature. If you aren't
+     * Equal to CURVE.getN().shiftRight(1), used for canonicalizing the S value of a signature. If you aren't
      * sure what this is about, you can ignore it.
      */
     private static final BigInteger HALF_CURVE_ORDER;

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -53,17 +53,11 @@ import java.util.Objects;
  */
 public class Bouncy256k1 implements Secp256k1 {
 
-    // The parameters of the secp256k1 curve that Bitcoin uses.
+    // The Bouncy Castle class containing parameters of the secp256k1 curve that Bitcoin uses.
     private static final X9ECParameters BC_CURVE_PARAMS = CustomNamedCurves.getByName("secp256k1");
 
-    /** The parameters of the secp256k1 curve that Bitcoin uses. */
+    /** The Bouncy Castle class containing parameters of the secp256k1 curve that Bitcoin uses. */
     static final ECDomainParameters BC_CURVE;
-
-    /**
-     * Equal to CURVE.getN().shiftRight(1), used for canonicalizing the S value of a signature. If you aren't
-     * sure what this is about, you can ignore it.
-     */
-    private static final BigInteger HALF_CURVE_ORDER;
 
     private static final SecureRandom secureRandom;
 
@@ -74,7 +68,6 @@ public class Bouncy256k1 implements Secp256k1 {
                 BC_CURVE_PARAMS.getG(),
                 BC_CURVE_PARAMS.getN(),
                 BC_CURVE_PARAMS.getH());
-        HALF_CURVE_ORDER = BC_CURVE_PARAMS.getN().shiftRight(1);
         // TODO: Verify using cryptographic random number generator properly
         try {
             secureRandom = SecureRandom.getInstanceStrong();

--- a/secp-bouncy/src/test/java/org/bitcoinj/secp/bouncy/BouncyCurveParamsTest.java
+++ b/secp-bouncy/src/test/java/org/bitcoinj/secp/bouncy/BouncyCurveParamsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.bouncy;
+
+import org.bitcoinj.secp.Secp256k1;
+import org.bitcoinj.secp.SecpFieldElement;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests comparing Bouncy Castle curve parameters with Secp256k1 curve parameters (some of which use JCA types.)
+ * This is a "Rosetta Stone" comparing Secp256k1/JCA parameters with their Bouncy Castle equivalent.
+ */
+public class BouncyCurveParamsTest {
+    @Test
+    void curveParamCompare() {
+        // "P" = "P"
+        assertEquals(Secp256k1.P, Bouncy256k1.BC_CURVE.getCurve().getField().getCharacteristic());
+        // "G" = "G"
+        assertEquals(Secp256k1.G, BC.toP256K1Point(Bouncy256k1.BC_CURVE.getG()));
+        // "Order" = "N"
+        assertEquals(Secp256k1.EC_PARAMS.getOrder(), Bouncy256k1.BC_CURVE.getN());
+        // HALF_CURVE_ORDER = HALF_CURVE_ORDER
+        assertEquals(Secp256k1.HALF_CURVE_ORDER, SecpFieldElement.of(Bouncy256k1.BC_CURVE.getN().shiftRight(1)));
+        // "Cofactor" = "H"
+        assertEquals(Secp256k1.EC_PARAMS.getCofactor(), Bouncy256k1.BC_CURVE.getH().intValueExact());
+        // "A" = "A"
+        assertEquals(Secp256k1.CURVE.getA(), Bouncy256k1.BC_CURVE.getCurve().getA().toBigInteger());
+        // "B" = "B"
+        assertEquals(Secp256k1.CURVE.getB(), Bouncy256k1.BC_CURVE.getCurve().getB().toBigInteger());
+    }
+}


### PR DESCRIPTION
A series of minor improvements, including:

* adding `SecpResult.isOk()` for convenience when checking results.
* adding `SecpFieldElement.isLowR()` for checking if a field element would be considered "low R"
* adding a definition for `HALF_CURVE_ORDER` which will help with "low S" (`isCanonical()`) checking (TBD)
