### PR TITLE
add Secp256k1.xOnlyPubKeyParse() FFM implementation

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -196,6 +196,13 @@ public interface Secp256k1 extends Closeable {
     SecpResult<SecpPubKey> ecPubKeyParse(byte[] inputData);
 
     /**
+     * Parse a byte array as an x-only public key
+     * @param inputData raw data to parse as an x-only public key
+     * @return an x-only public key result or error
+     */
+    SecpResult<SecpXOnlyPubKey> xOnlyPubKeyParse(byte[] inputData);
+
+    /**
      * Sign a message hash using the ECDSA algorithm
      * @param msg_hash_data hash of message to sign
      * @param seckey private key

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpXOnlyPubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpXOnlyPubKey.java
@@ -38,9 +38,13 @@ public interface SecpXOnlyPubKey {
 
     /**
      * Parses a serialized x-only pubkey and returns an instance of the default implementation
+     * <p>
+     * This method is <b>deprecated</b> because it <b>does not validate</b> they x-only pubkey.
      * @param serialized byte string in x-only pubkey serialization format
      * @return an instance of the default implementation
+     * @deprecated Use {@link Secp256k1#xOnlyPubKeyParse(byte[])} instead
      */
+    @Deprecated(forRemoval = true)
     static SecpResult<SecpXOnlyPubKey> parse(byte[] serialized) {
         return !SecpFieldElementImpl.isInRange(serialized)
                 ? SecpResult.err(-1)

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpXOnlyPubKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpXOnlyPubKeyImpl.java
@@ -31,6 +31,11 @@ public class SecpXOnlyPubKeyImpl implements SecpXOnlyPubKey, ByteArray {
         this.x = x.serialize();
     }
 
+    // Only call this method for x-only pubkeys that have been verified as valid
+    public static SecpXOnlyPubKeyImpl ofVerifiedBytes(byte[] bytes) {
+        return new SecpXOnlyPubKeyImpl(SecpFieldElement.of(bytes));
+    }
+
     @Override
     public BigInteger getX() {
         return ByteArray.toInteger(x);

--- a/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
+++ b/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
@@ -90,6 +90,8 @@ public class AddressTest {
         Address tapRootAddress;
         try (Secp256k1 secp = Secp256k1.getById(BOUNCY_CASTLE)) {
             byte[] serial = HexFormat.of().parseHex("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
+            // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
+            // We need a Bouncy Castle Implementation first
             SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(serial).get();
             BigInteger tweakInt = calcTweak(xOnlyKey);
             SecpPubKey G = new SecpPubKeyImpl(Secp256k1.G);
@@ -119,6 +121,8 @@ public class AddressTest {
             System.arraycopy(xbytes, 0, compressed, 1, 32);
             ECKey ecKey = ECKey.fromPublicOnly(compressed);
             SecpPubKey pubkey = BC.toP256K1PubKey(ecKey.getPubKeyPoint());
+            // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
+            // We need a Bouncy Castle Implementation first
             SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(UInt256.integerTo32Bytes(internalPubKey)).get();
             BigInteger tweakInt = calcTweak(xOnlyKey);
             SecpPubKey G = new SecpPubKeyImpl(Secp256k1.G);

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -147,6 +147,11 @@ public class Bouncy256k1 implements Secp256k1 {
         return SecpResult.ok(BC.toP256K1PubKey(bcPoint));
     }
 
+    @Override
+    public SecpResult<SecpXOnlyPubKey> xOnlyPubKeyParse(byte[] inputData) {
+        throw new UnsupportedOperationException();
+    }
+
     // TODO: Add constructor to create SignatureData from r and s
     @Override
     public SecpResult<EcdsaSignature> ecdsaSign(byte[] msg_hash_data, SecpPrivKey privKey) {

--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Schnorr.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Schnorr.java
@@ -47,7 +47,7 @@ public class Schnorr {
 
             /* === Verification === */
 
-            SecpXOnlyPubKey xOnly2 = SecpXOnlyPubKey.parse(serializedXOnly).get();
+            SecpXOnlyPubKey xOnly2 = secp.xOnlyPubKeyParse(serializedXOnly).get();
 
             /* Compute the tagged hash on the received message using the same tag as the signer. */
             byte[] messageHash2 = secp.taggedSha256(tag, msg);

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Schnorr.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Schnorr.kt
@@ -41,7 +41,7 @@ fun main() {
         val signature = secp.schnorrSigSign32(messageHash, keyPair)
 
         /* === Verification === */
-        val xOnly2 : SecpXOnlyPubKey = SecpXOnlyPubKey.parse(serializedXOnly).get()
+        val xOnly2 : SecpXOnlyPubKey = secp.xOnlyPubKeyParse(serializedXOnly).get()
 
         /* Compute the tagged hash on the received message using the same tag as the signer. */
         val messageHash2 = secp.taggedSha256(tag, msg)

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -17,6 +17,7 @@ package org.bitcoinj.secp.ffm;
 
 import org.bitcoinj.secp.ByteArray;
 import org.bitcoinj.secp.EcdhSharedSecret;
+import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpKeyPair;
 import org.bitcoinj.secp.SecpPubKey;
 import org.bitcoinj.secp.SecpResult;
@@ -35,6 +36,7 @@ import org.bitcoinj.secp.ffm.jextract.secp256k1_keypair;
 import org.bitcoinj.secp.ffm.jextract.secp256k1_pubkey;
 import org.bitcoinj.secp.ffm.jextract.secp256k1_xonly_pubkey;
 import org.bitcoinj.secp.internal.SchnorrSignatureImpl;
+import org.bitcoinj.secp.internal.SecpXOnlyPubKeyImpl;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -49,6 +51,7 @@ import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.C_POINTER;
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.NULL;
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.SECP256K1_EC_UNCOMPRESSED;
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.secp256k1_schnorrsig_sign32;
+import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.secp256k1_xonly_pubkey_serialize;
 
 /**
  * Implementation of {@link Secp256k1} using the {@code secp256k1} C-language library and the Java Foreign Function &amp; Memory API.
@@ -289,6 +292,19 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
             System.out.println("Failed parsing the public key\n");
         }
         return SecpResult.checked(return_val, () -> new SecpPubKeyImpl(toPoint(pubkey)));
+    }
+
+    @Override
+    public SecpResult<SecpXOnlyPubKey> xOnlyPubKeyParse(byte[] inputData) {
+        if (inputData.length != 32) throw new IllegalArgumentException("length != 32");
+        MemorySegment input = arena.allocateFrom(JAVA_BYTE, inputData);
+        MemorySegment xOnly = secp256k1_xonly_pubkey.allocate(arena);
+        int return_val = secp256k1_h.secp256k1_xonly_pubkey_parse(ctx, xOnly, input);
+        if (return_val != 1) return SecpResult.err(return_val);
+        // Surprisingly, secp256k1_xonly_pubkey is 64 opaque bytes, so we need to serialize to get 32 bytes
+        MemorySegment serializedXOnly = arena.allocate(32);
+        secp256k1_xonly_pubkey_serialize(ctx, serializedXOnly, xOnly);  // Always returns 1
+        return SecpResult.ok(new SecpXOnlyPubKeyImpl(SecpFieldElement.of(serializedXOnly.toArray(JAVA_BYTE))));
     }
 
     private SecpResult<MemorySegment> pubKeyParse(SecpPubKey pubKeyData) {

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -301,7 +301,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         // Surprisingly, secp256k1_xonly_pubkey is 64 opaque bytes, so we need to serialize to get 32 bytes
         MemorySegment serializedXOnly = arena.allocate(32);
         secp256k1_xonly_pubkey_serialize(ctx, serializedXOnly, xOnly);  // Always returns 1
-        return SecpResult.ok(new SecpXOnlyPubKeyImpl(SecpFieldElement.of(serializedXOnly.toArray(JAVA_BYTE))));
+        return SecpResult.ok(SecpXOnlyPubKeyImpl.ofVerifiedBytes(serializedXOnly.toArray(JAVA_BYTE)));
     }
 
     private SecpResult<MemorySegment> pubKeyParse(SecpPubKey pubKeyData) {

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -288,9 +288,6 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         MemorySegment input = arena.allocateFrom(JAVA_BYTE, inputData);
         MemorySegment pubkey = secp256k1_pubkey.allocate(arena);
         int return_val = secp256k1_h.secp256k1_ec_pubkey_parse(ctx, pubkey, input, input.byteSize());
-        if (return_val != 1) {
-            System.out.println("Failed parsing the public key\n");
-        }
         return SecpResult.checked(return_val, () -> new SecpPubKeyImpl(toPoint(pubkey)));
     }
 


### PR DESCRIPTION
* Add Secp256k1.xOnlyPubKeyParse() API
* Add xOnlyPubKeyParse() FFM implementation
* Throw UnsupportedOperationException in Bouncy implementation
* Replace SecpXOnlyPubKey.parse() with Secp256k1.xOnlyPubKeyParse() in example
* Deprecate SecpXOnlyPubKey.parse()

We need to continue using the deprecated version in the experimental bitcoinj test module (taproot experiments), but that usage can be updated when we have a Bouncy Castle implementation of Secp256k1.xOnlyPubKeyParse().