### PR TITLE
Secp256k1, Secp256k1Foreign: add ecdsaSignLowR() method 

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -215,6 +215,16 @@ public interface Secp256k1 extends Closeable {
     SecpResult<EcdsaSignature> ecdsaSign(byte[] msg_hash_data, SecpPrivKey privKey);
 
     /**
+     * Sign a message hash using the ECDSA algorithm and Low-R signature griding
+     * <p>
+     * This uses the same nonce-incrementing algorithm as Bitcoin Core to ensure a low-R signature.
+     * @param messageHashData hash of message to sign
+     * @param privKey private key
+     * @return the signature
+     */
+    SecpResult<EcdsaSignature> ecdsaSignLowR(byte[] messageHashData, SecpPrivKey privKey);
+
+    /**
      * Serialize a {@link EcdsaSignature} as a Bitcoin <i>compact signature</i>. A compact signature is
      * the two signature component field integers (known as {@code r} and {@code s}) serialized in-order as
      * binary data in big-endian format.

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -167,6 +167,27 @@ public class Bouncy256k1 implements Secp256k1 {
         return SecpResult.ok(ecdsaSignature(components));
     }
 
+    @Override
+    public SecpResult<EcdsaSignature> ecdsaSignLowR(byte[] messageHashData, SecpPrivKey privKey) {
+        HMacDSAKCalculatorWithEntropy kCalculator = new HMacDSAKCalculatorWithEntropy(new SHA256Digest());
+        ECDSASigner signer = new ECDSASigner(kCalculator);
+        ECPrivateKeyParameters bouncyPrivKey = new ECPrivateKeyParameters(privKey.getS(), BC_CURVE);
+        signer.init(true, bouncyPrivKey);
+        BigInteger[] components = signer.generateSignature(messageHashData);
+        // grind for low R values by adding entropy to the K calculation via RFC 6979 section 3.6.
+        // see discussion at https://github.com/bitcoin/bitcoin/pull/13666
+        for (int counter = 1; !hasLowR(components[0]) && counter < Integer.MAX_VALUE; counter++) {
+            kCalculator.setEntropy(counter);
+            components = signer.generateSignature(messageHashData);
+        }
+        return SecpResult.ok(ecdsaSignature(components));
+    }
+
+    private static boolean hasLowR(BigInteger r) {
+        // TODO: check low-r directly on BigInteger
+        return SecpScalarImpl.integerTo32Bytes(r)[0] >= 0;
+    }
+
     // Convert and canonicalize signature
     private EcdsaSignature ecdsaSignature(BigInteger[] components) {
         return EcdsaSignature.of(

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/HMacDSAKCalculatorWithEntropy.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/HMacDSAKCalculatorWithEntropy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.bouncy;
+
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.macs.HMac;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
+import org.jspecify.annotations.Nullable;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Objects;
+
+/**
+ * Custom K calculator with ability to add additional entropy to the calculation. This is needed for grinding for
+ * low signature R values. Before calling {@link #setEntropy(byte[])}, no entropy is added.
+ */
+class HMacDSAKCalculatorWithEntropy extends HMacDSAKCalculator {
+
+    byte @Nullable[] entropy = null;
+
+    HMacDSAKCalculatorWithEntropy(Digest digest) {
+        super(digest);
+    }
+
+    /**
+     * Add 32 bytes of additional entropy to the K calculation via RFC 6979.
+     *
+     * @param entropy 32 bytes of entropy
+     * @see
+     * <a href="https://www.rfc-editor.org/rfc/rfc6979#section-3.6">RFC 6979 section 3.6. "Additional data…"</a>
+     */
+    private void setEntropy(byte[] entropy) {
+        Objects.requireNonNull(entropy);
+        checkArg(entropy.length == 32, "entropy must be 32 bytes");
+        this.entropy = entropy;
+    }
+
+    public void setEntropy(int counter) {
+        byte[] entropy =
+                ByteBuffer.allocate(32).order(ByteOrder.LITTLE_ENDIAN).putInt(0, counter).array();
+        setEntropy(entropy);
+    }
+
+    @Override
+    protected void initAdditionalInput0(HMac hmac0) {
+        if (entropy != null)
+            hmac0.update(entropy, 0, 32);
+    }
+
+    @Override
+    protected void initAdditionalInput1(HMac hmac1) {
+        if (entropy != null)
+            hmac1.update(entropy, 0, 32);
+    }
+
+    private static void checkArg(boolean condition, String string) {
+        if (!condition) {
+            throw new IllegalArgumentException(string);
+        }
+    }
+ }

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -25,6 +25,7 @@ import org.bitcoinj.secp.SecpPrivKey;
 import org.bitcoinj.secp.SchnorrSignature;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.ffm.segments.LowRGrindingNonce;
 import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.SecpKeyPairImpl;
 import org.bitcoinj.secp.internal.SecpPointUncompressed;
@@ -46,6 +47,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static org.bitcoinj.secp.SecpResult.OK;
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.C_POINTER;
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.SECP256K1_EC_UNCOMPRESSED;
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.secp256k1_schnorrsig_sign32;
@@ -318,6 +320,40 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         privKeySeg.fill((byte) 0x00);
         secp256k1_h.secp256k1_ecdsa_signature_serialize_compact(ctx, serSigSeg, sig);
         return SecpResult.checked(return_val, () -> EcdsaSignature.of(serSigSeg.toArray(JAVA_BYTE)));
+    }
+
+    /**
+     * ECDSA signing with Low-R grinding. Will potentially sign multiple times until a low-R signature is generated.
+     * @param msg_hash_data hashed message data
+     * @param privKey private key
+     * @return A result, which on success contains a valid signature with a low R value.
+     */
+    @Override
+    public SecpResult<EcdsaSignature> ecdsaSignLowR(byte[] msg_hash_data, SecpPrivKey privKey) {
+        MemorySegment msg_hash = arena.allocateFrom(JAVA_BYTE, msg_hash_data);
+        MemorySegment privKeySeg = arena.allocateFrom(JAVA_BYTE, privKey.getEncoded());
+        MemorySegment sig = secp256k1_ecdsa_signature.allocate(arena);  // internal signature format
+        MemorySegment serSigSeg = secp256k1_ecdsa_signature.allocate(arena);  // serialized signature format
+        LowRGrindingNonce nonce = LowRGrindingNonce.zero(arena);
+        int count = 0;
+        int return_val;
+        do {
+            // Sign the message, producing a signature in `sig`
+            if (count++ == 0) {
+                return_val = secp256k1_h.secp256k1_ecdsa_sign(ctx, sig, msg_hash, privKeySeg, NULL, NULL);
+            } else {
+                return_val = secp256k1_h.secp256k1_ecdsa_sign(ctx, sig, msg_hash, privKeySeg, NULL, nonce.segment());
+            }
+            secp256k1_h.secp256k1_ecdsa_signature_serialize_compact(ctx, serSigSeg, sig);
+            nonce.increment();                      // Increment the counter field in the nonce
+        } while (return_val == OK && !hasLowR(serSigSeg)); // Retry until we get an error or low-R
+        privKeySeg.fill((byte) 0x00);
+        return SecpResult.checked(return_val, () -> EcdsaSignature.of(serSigSeg.toArray(JAVA_BYTE)));
+    }
+
+    private static boolean hasLowR(MemorySegment serSigSeg) {
+        byte highByte = serSigSeg.toArray(JAVA_BYTE)[0];
+        return highByte >= 0;
     }
 
     @Override

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonce.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonce.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.ffm.segments;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+
+/**
+ * Memory layout for working with Low-R grinding nonces. A 32-byte segment with a 4-byte, little-endian
+ * counter at offset zero.
+ */
+public class LowRGrindingNonce {
+    static final ValueLayout.OfInt COUNT_LAYOUT = ValueLayout.JAVA_INT.withOrder(ByteOrder.LITTLE_ENDIAN);
+    static final StructLayout LAYOUT = MemoryLayout.structLayout(
+            COUNT_LAYOUT.withName("counter"),     // 4 bytes
+            MemoryLayout.sequenceLayout(28, ValueLayout.JAVA_BYTE).withName("remaining")   // 28 bytes
+    );
+    static private final long COUNT_OFFSET = LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("counter"));
+
+    private final MemorySegment segment;
+    private int counter;
+
+    private LowRGrindingNonce(MemorySegment segment) {
+        this.segment = segment;
+        this.counter = 0;
+    }
+
+    public static LowRGrindingNonce zero(Arena arena) {
+        return new LowRGrindingNonce(arena.allocate(LAYOUT.byteSize()));
+    }
+
+    public void increment() {
+        segment.set(COUNT_LAYOUT, COUNT_OFFSET, ++counter);
+    }
+
+    public MemorySegment segment() {
+        return segment;
+    }
+
+    public byte[] bytes() {
+        return segment.toArray(ValueLayout.JAVA_BYTE);
+    }
+}

--- a/secp-ffm/src/test/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonceTest.java
+++ b/secp-ffm/src/test/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.ffm.segments;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * Basic test of {@link LowRGrindingNonce}
+ */
+public class LowRGrindingNonceTest {
+    static final byte[] nonce0 = new byte[32];
+    static final byte[] nonce1 = HexFormat.of().parseHex("01" + "00".repeat(31));
+
+    @Test
+    void basicTest() {
+        try (var arena = Arena.ofShared()) {
+            var nonce = LowRGrindingNonce.zero(arena);
+            assertArrayEquals(nonce0, nonce.bytes(), "");
+            nonce.increment();
+            assertArrayEquals(nonce1, nonce.bytes(), "");
+        }
+    }
+}

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaLowRTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaLowRTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.integration;
+
+import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.Secp256k1;
+import org.bitcoinj.secp.SecpPrivKey;
+import org.bitcoinj.secp.SecpPubKey;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+import static org.bitcoinj.secp.integration.SecpTestSupport.parseHex;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// secp256k1-jdk integration tests for low-R ECDSA signing.
+///
+/// Bitcoin Core [PR #13666](https://github.com/bitcoin/bitcoin/pull/13666) introduced low-r ECDSA signature grinding.
+/// This has been the default behavior since [release 0.17](https://bitcoincore.org/en/releases/0.17.0/) and several other
+/// libraries and wallets have implemented the same (or similar) algorithms. There is no BIP (yet!) with official
+/// test vectors (yet!), but the Bitcoin Core C++ implementation serves as a reference implementation.
+///
+/// [Bitcoin Optech](https://bitcoinops.org) has a [Low-r grinding](https://bitcoinops.org/en/topics/low-r-grinding/) topic
+/// with additional information and links to a few other implementations.
+@ParameterizedClass
+@MethodSource("secpImplementations")
+public class EcdsaLowRTest implements SecpTestSupport {
+
+    /// Test Vector Record
+    /// @param message 32-byte message (hash) to sign
+    /// @param privKey private key for signing
+    /// @param signature expected signature
+    record LowRVector(byte[] message, byte[] privKey, byte[] signature) {
+        static LowRVector parse(String message, String privKey, String signature) {
+            return new LowRVector(parseHex(message), parseHex(privKey), parseHex(signature));
+        }
+    }
+
+    /// test vector from [rust-secp256k1](https://github.com/rust-bitcoin/rust-secp256k1/pull/259/files)
+    static List<LowRVector> vectors = List.of(LowRVector.parse(
+            "887d04bb1cf1b1554f1b268dfe62d13064ca67ae45348d50d1392ce2d13418ac",
+            "57f0148f94d13095cfda539d0da0d1541304b678d8b36e243980aab4e1b7cead",
+            "047dd4d049db02b430d24c41c7925b2725bcd5a85393513bdec04b4dc363632b1054d0180094122b380f4cfa391e6296244da773173e78fc745c1b9c79f7b713"
+    ));
+
+    private final Secp256k1 secp;
+
+    /// Tests for Low-R ECDSA Signing
+    /// @param secp injected Secp256k1 implementation to test
+    EcdsaLowRTest(Secp256k1 secp) {
+        this.secp = secp;
+    }
+
+    /// Parameterized low-R signing test (currently only a single test vector)
+    /// @param vec test vector
+    @FieldSource("vectors")
+    @ParameterizedTest(name = "Test Ecdsa for {0}")
+    void testEcdsaLowR(LowRVector vec) {
+        SecpPrivKey privKey = SecpPrivKey.of(vec.privKey);
+        SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
+
+        // Sign
+        EcdsaSignature sig = secp.ecdsaSignLowR(vec.message, privKey).get();
+
+        // Signature should be bit-for-bit identical with signature in test vector
+        assertArrayEquals(vec.signature, sig.serializeCompact());
+
+        // Verify and check for low-r
+        boolean validSignature = secp.ecdsaVerify(sig, vec.message, pubKey).get();
+
+        assertTrue(validSignature);
+        assertTrue(sig.hasLowR());
+    }
+}

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
@@ -45,6 +45,17 @@ public class EcdsaTest implements SecpTestSupport {
         assertTrue(validSignature);
     }
 
+    @MethodSource("secpImplementations")
+    @ParameterizedTest(name = "Test Ecdsa for {0}")
+    void testEcdsaLowR(Secp256k1 secp) {
+        SecpPrivKey privKey = secp.ecPrivKeyCreate();
+        SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
+        EcdsaSignature sig = secp.ecdsaSignLowR(msg_hash, privKey).get();
+        boolean validSignature = secp.ecdsaVerify(sig, msg_hash, pubKey).get();
+        assertTrue(validSignature);
+        assertTrue(sig.hasLowR());
+    }
+
     @Test
     void ecdsaCrossCheck() {
         try (Secp256k1 secp1 = new Secp256k1Foreign(); Secp256k1 secp2 = new Bouncy256k1()) {
@@ -58,6 +69,30 @@ public class EcdsaTest implements SecpTestSupport {
 
             EcdsaSignature sig1 = secp1.ecdsaSign(msg_hash, secKey1).get();
             EcdsaSignature sig2 = secp2.ecdsaSign(msg_hash, secKey2).get();
+
+            assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
+
+            assertTrue(secp1.ecdsaVerify(sig1, msg_hash, pubKey1).get());
+            assertTrue(secp1.ecdsaVerify(sig2, msg_hash, pubKey2).get());
+            assertTrue(secp2.ecdsaVerify(sig1, msg_hash, pubKey1).get());
+            assertTrue(secp2.ecdsaVerify(sig2, msg_hash, pubKey2).get());
+        }
+    }
+
+
+    @Test
+    void ecdsaCrossCheckLowR() {
+        try (Secp256k1 secp1 = new Secp256k1Foreign(); Secp256k1 secp2 = new Bouncy256k1()) {
+            SecpPrivKey secKey1 = secp1.ecPrivKeyCreate();
+            SecpPubKey pubKey1 = secp1.ecPubKeyCreate(secKey1);
+
+            SecpPrivKey secKey2 = secKey1;
+            SecpPubKey pubKey2 = secp2.ecPubKeyCreate(secKey1);
+
+            assertArrayEquals(pubKey1.serialize(), pubKey2.serialize());
+
+            EcdsaSignature sig1 = secp1.ecdsaSignLowR(msg_hash, secKey1).get();
+            EcdsaSignature sig2 = secp2.ecdsaSignLowR(msg_hash, secKey2).get();
 
             assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
 


### PR DESCRIPTION
~~This is a child of PR #308 and should be rebased when that is merged.~~

~~This needs test vectors.~~ Tests are now included. More tests could always be added, of course.
 