### PR TITLE
OpaqueKeyPair: add some comments and create PR as a reminder

### DIFF
--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/OpaqueKeyPair.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/OpaqueKeyPair.java
@@ -40,16 +40,15 @@ class OpaqueKeyPair implements SecpKeyPair {
 
     @Override
     public SecpPubKey publicKey() {
+        // Create a keyPairSegment from opaque
         MemorySegment keyPairSegment = Secp256k1Foreign.globalArena.allocateFrom(JAVA_BYTE, opaque);
+        // Create a pubKeySegment from a keyPairSegment using secp256k1_context_static()
         MemorySegment pubKeySegment = secp256k1_pubkey.allocate(Secp256k1Foreign.globalArena);
         int return_val = secp256k1_h.secp256k1_keypair_pub(secp256k1_h.secp256k1_context_static(), pubKeySegment, keyPairSegment);
         assert(return_val == 1);
+        // Convert the pubKeySegment to a SecpPubKey
         ECPoint pubKeyPoint = Secp256k1Foreign.toPoint(pubKeySegment);
         return new SecpPubKeyImpl(pubKeyPoint);
-    }
-
-    public byte[] getOpaque() {
-        return opaque.clone();
     }
 
     public SecpPrivKey privateKey() {
@@ -58,15 +57,17 @@ class OpaqueKeyPair implements SecpKeyPair {
 
     @Override
     public byte[] getEncoded() {
+        // Create a keyPairSegment from opaque
         MemorySegment keyPairSegment = Secp256k1Foreign.globalArena.allocateFrom(JAVA_BYTE, opaque);
+        // Create a privKeySegment from a keyPairSegment using secp256k1_context_static()
         MemorySegment privKeySegment = Secp256k1Foreign.globalArena.allocate(32);
         int return_val = secp256k1_h.secp256k1_keypair_sec(secp256k1_h.secp256k1_context_static(), privKeySegment, keyPairSegment);
         assert(return_val == 1);
+        // return the private key as byte[]
         return privKeySegment.toArray(JAVA_BYTE);
     }
 
     @Override
     public void destroy() {
-        // TODO
     }
 }


### PR DESCRIPTION
`OpaqueKeyPair` has been removed. I kept it around for a while because I want to reuse code from the `publicKey()` and `getEncoded()` methods in either `Secp256k1Foreign` or maybe a `KeyPairSegment` class.

This draft PR better documents what is going on in those methods and serves as a reminder to use this code elsewhere.