### PR TITLE
Secp256k1: return `boolean` not `SecpResult<Boolean>` from verification

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -237,9 +237,9 @@ public interface Secp256k1 extends Closeable {
      * @param sig The signature to verify.
      * @param msg_hash_data A hash of the message to verify.
      * @param pubKey The pubkey that must have signed the message
-     * @return true, false, or error
+     * @return true if successfully verified, false otherwise
      */
-    SecpResult<Boolean> ecdsaVerify(EcdsaSignature sig, byte[] msg_hash_data, SecpPubKey pubKey);
+    boolean ecdsaVerify(EcdsaSignature sig, byte[] msg_hash_data, SecpPubKey pubKey);
 
     /**
      * Generate a tagged SHA-256 hash.
@@ -272,18 +272,18 @@ public interface Secp256k1 extends Closeable {
      * @param signature the signature to verify
      * @param msg_hash hash of the message
      * @param pubKey x-only pubkey that must have signed the message
-     * @return true, false, or error
+     * @return true if successfully verified, false otherwise
      */
-    SecpResult<Boolean> schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey);
+    boolean schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey);
 
     /**
      * Verify a Schnorr signature.
      * @param signature the signature to verify
      * @param msg_hash hash of the message
      * @param pubKey pubkey that must have signed the message
-     * @return true, false, or error
+     * @return true if successfully verified, false otherwise
      */
-    default SecpResult<Boolean> schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpPubKey pubKey) {
+    default boolean schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpPubKey pubKey) {
         return schnorrSigVerify(signature, msg_hash, pubKey.xOnly());
     }
 

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -196,7 +196,7 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public SecpResult<Boolean> ecdsaVerify(EcdsaSignature signature, byte[] msg_hash_data, SecpPubKey pubKey) {
+    public boolean ecdsaVerify(EcdsaSignature signature, byte[] msg_hash_data, SecpPubKey pubKey) {
         ECDSASigner signer = new ECDSASigner();
         java.security.spec.ECPoint jPoint = pubKey.getW();
         org.bouncycastle.math.ec.ECPoint pubPoint = BC.fromECPoint(jPoint);
@@ -211,7 +211,7 @@ public class Bouncy256k1 implements Secp256k1 {
             //log.error("Caught NPE inside bouncy castle", e);
             result = false;
         }
-        return SecpResult.ok(result);
+        return result;
     }
 
     @Override
@@ -225,8 +225,8 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public SecpResult<Boolean> schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey) {
-        return SecpResult.err(-1);
+    public boolean schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
@@ -65,7 +65,7 @@ public class Ecdsa {
             assert(pubkey.getW().equals(pubkey2.getW()));
 
             /* Verify a signature. This will return true if it's valid and false if it's not. */
-            boolean isValidSignature = secp.ecdsaVerify(sig2, messageHash, pubkey2).get();
+            boolean isValidSignature = secp.ecdsaVerify(sig2, messageHash, pubkey2);
 
             IO.println("Is the signature valid? " + isValidSignature);
             IO.println("Secret Key: " + privKey.getS().toString(16));

--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Schnorr.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Schnorr.java
@@ -52,7 +52,7 @@ public class Schnorr {
             /* Compute the tagged hash on the received message using the same tag as the signer. */
             byte[] messageHash2 = secp.taggedSha256(tag, msg);
 
-            boolean isValidSignature = secp.schnorrSigVerify(signature, messageHash2, xOnly2).get();
+            boolean isValidSignature = secp.schnorrSigVerify(signature, messageHash2, xOnly2);
 
             IO.println("Is the signature valid? " + isValidSignature);
             IO.println("Secret Key: " + keyPair.getS().toString(16));

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
@@ -66,7 +66,7 @@ fun main() {
         assert(pubkey.w == pubkey2.w)
 
         /* Verify a signature. This will return true if it's valid and false if it's not. */
-        val isValidSignature : Boolean = secp.ecdsaVerify(sig2, messageHash, pubkey2).get()
+        val isValidSignature : Boolean = secp.ecdsaVerify(sig2, messageHash, pubkey2)
 
         println("Is the signature valid? $isValidSignature")
         println("Secret Key: ${privKey.s.toString(16)}")

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Schnorr.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Schnorr.kt
@@ -56,7 +56,7 @@ fun main() {
         /* Compute the tagged hash on the received message using the same tag as the signer. */
         val messageHash2 : ByteArray = secp.taggedSha256(tag, msg)
 
-        val isValidSignature : Boolean = secp.schnorrSigVerify(signature, messageHash2, xOnly2).get()
+        val isValidSignature : Boolean = secp.schnorrSigVerify(signature, messageHash2, xOnly2)
 
         println("Is the signature valid? $isValidSignature")
         println("Secret Key: ${keyPair.s.toString(16)}")

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -333,22 +333,22 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     @Override
-    public SecpResult<Boolean> ecdsaVerify(EcdsaSignature sig, byte[] msg_hash_data, SecpPubKey pubKey) {
+    public boolean ecdsaVerify(EcdsaSignature sig, byte[] msg_hash_data, SecpPubKey pubKey) {
         /* Generate an ECDSA signature `noncefp` and `ndata` allows you to pass a
          * custom nonce function, passing `NULL` will use the RFC-6979 safe default.
          * Signing with a valid context, verified secret key
          * and the default nonce function should never fail. */
         MemorySegment msg_hash = arena.allocateFrom(JAVA_BYTE, msg_hash_data);
         SecpResult<MemorySegment> parsedPubKey = pubKeyParse(pubKey);
+        if (parsedPubKey.errorCode() != SecpResult.OK) throw new IllegalStateException("previously validated public key is invalid");
         MemorySegment serSigSeg =  arena.allocateFrom(JAVA_BYTE, sig.serializeCompact());
         MemorySegment sigSeg = secp256k1_ecdsa_signature.allocate(arena);   // internal format
         secp256k1_h.secp256k1_ecdsa_signature_parse_compact(ctx, sigSeg, serSigSeg);
-        if (parsedPubKey instanceof SecpResult.Err<MemorySegment> err) return SecpResult.err(err.code());
         int return_val = secp256k1_h.secp256k1_ecdsa_verify(ctx,
                 sigSeg,
                 msg_hash,
                 parsedPubKey.get());
-        return SecpResult.ok(return_val == 1);
+        return return_val == 1;
     }
 
     @Override
@@ -411,15 +411,15 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     @Override
-    public SecpResult<Boolean> schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey) {
+    public boolean schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey) {
         MemorySegment sigSegment = arena.allocateFrom(JAVA_BYTE, signature.bytes());
         MemorySegment msgSegment = arena.allocateFrom(JAVA_BYTE, msg_hash);
         MemorySegment pubKeySegment = arena.allocateFrom(JAVA_BYTE, pubKey.serialize()); // 32-byte
         MemorySegment pubKeySegmentOpaque = secp256k1_xonly_pubkey.allocate(arena); // 64-byte opaque
         int r = secp256k1_h.secp256k1_xonly_pubkey_parse(ctx, pubKeySegmentOpaque, pubKeySegment);
-        if (r != 1) return SecpResult.err(r);
+        if (r != 1) throw new IllegalStateException("x-only pub key should have been previously validated");
         int return_val = secp256k1_h.secp256k1_schnorrsig_verify(ctx, sigSegment, msgSegment, msg_hash.length, pubKeySegmentOpaque);
-        return SecpResult.ok(return_val == 1);
+        return return_val == 1;
     }
 
     @Override

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
@@ -41,7 +41,7 @@ public class EcdsaTest implements SecpTestSupport {
         SecpPrivKey privKey = secp.ecPrivKeyCreate();
         SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
         EcdsaSignature sig = secp.ecdsaSign(msg_hash, privKey).get();
-        boolean validSignature = secp.ecdsaVerify(sig, msg_hash, pubKey).get();
+        boolean validSignature = secp.ecdsaVerify(sig, msg_hash, pubKey);
         assertTrue(validSignature);
     }
 
@@ -61,10 +61,10 @@ public class EcdsaTest implements SecpTestSupport {
 
             assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
 
-            assertTrue(secp1.ecdsaVerify(sig1, msg_hash, pubKey1).get());
-            assertTrue(secp1.ecdsaVerify(sig2, msg_hash, pubKey2).get());
-            assertTrue(secp2.ecdsaVerify(sig1, msg_hash, pubKey1).get());
-            assertTrue(secp2.ecdsaVerify(sig2, msg_hash, pubKey2).get());
+            assertTrue(secp1.ecdsaVerify(sig1, msg_hash, pubKey1));
+            assertTrue(secp1.ecdsaVerify(sig2, msg_hash, pubKey2));
+            assertTrue(secp2.ecdsaVerify(sig1, msg_hash, pubKey1));
+            assertTrue(secp2.ecdsaVerify(sig2, msg_hash, pubKey2));
         }
     }
 }

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/SchnorrTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/SchnorrTest.java
@@ -39,7 +39,7 @@ public class SchnorrTest {
             SecpXOnlyPubKey xOnly = keyPair.publicKey().xOnly();
             byte[] messageHash = secp.taggedSha256(tag, msg);
             SchnorrSignature signature = secp.schnorrSigSign32(messageHash, keyPair);
-            boolean isValid = secp.schnorrSigVerify(signature, messageHash, xOnly).get();
+            boolean isValid = secp.schnorrSigVerify(signature, messageHash, xOnly);
             assertTrue(isValid);
         }
     }


### PR DESCRIPTION
To simplify the API, return a boolean primitive from the 3 signature verification methods. The only case where an actual error can occur is if a previously validated public key object contains invalid data, so in those cases we throw IllegalStateException.

**Update**: let's keep this as _DRAFT_ until we have better tests to make sure xOnlyPubKey and PubKey can _never_ have invalid values.