### PR TITLE
Secp256k1Foreign, BouncySecp256k1: serialization and canonicalization fixes

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
@@ -20,7 +20,7 @@ import org.bitcoinj.secp.internal.EcdsaSignatureImpl;
 /**
  * An secp256k1 ECDSA signature.
  */
-public interface EcdsaSignature extends ByteArray {
+public interface EcdsaSignature {
     /**
      * Get field element R
      * @return R
@@ -32,6 +32,13 @@ public interface EcdsaSignature extends ByteArray {
      * @return S
      */
     SecpFieldElement s();
+
+    /**
+     * Serialize as a Bitcoin <i>compact signature</i>. A compact signature is  the two signature component
+     * field integers (known as {@code r} and {@code s}) serialized in-order as binary data in big-endian format.
+     * @return a Bitcoin compact signature
+     */
+    byte[] serializeCompact();
 
     /**
      * Is this signature a "low R" signature.

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
@@ -57,7 +57,7 @@ public class EcdsaSignatureImpl implements EcdsaSignature {
     }
 
     @Override
-    public byte[] bytes() {
+    public byte[] serializeCompact() {
         byte[] signature = new byte[64];
         System.arraycopy(r.serialize(), 0, signature, 0, 32);
         System.arraycopy(s.serialize(), 0, signature, 32, 32);
@@ -66,6 +66,6 @@ public class EcdsaSignatureImpl implements EcdsaSignature {
 
     @Override
     public String toString() {
-        return this.formatHex();
+        return ByteArrayBase.toHexString(serializeCompact());
     }
 }

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -59,6 +59,12 @@ public class Bouncy256k1 implements Secp256k1 {
     /** The Bouncy Castle class containing parameters of the secp256k1 curve that Bitcoin uses. */
     static final ECDomainParameters BC_CURVE;
 
+    /**
+     * Equal to CURVE.getN().shiftRight(1), used for canonicalizing the S value of a signature. If you aren't
+     * sure what this is about, you can ignore it.
+     */
+    private static final BigInteger HALF_CURVE_ORDER;
+
     private static final SecureRandom secureRandom;
 
     static {
@@ -68,6 +74,7 @@ public class Bouncy256k1 implements Secp256k1 {
                 BC_CURVE_PARAMS.getG(),
                 BC_CURVE_PARAMS.getN(),
                 BC_CURVE_PARAMS.getH());
+        HALF_CURVE_ORDER = BC_CURVE_PARAMS.getN().shiftRight(1);
         // TODO: Verify using cryptographic random number generator properly
         try {
             secureRandom = SecureRandom.getInstanceStrong();
@@ -161,9 +168,16 @@ public class Bouncy256k1 implements Secp256k1 {
         ECPrivateKeyParameters bouncyPrivKey = new ECPrivateKeyParameters(privateKeyForSigning, BC_CURVE);
         signer.init(true, bouncyPrivKey);
         BigInteger[] components = signer.generateSignature(msg_hash_data);
+        BigInteger s = canonicalize(components[1]);
         EcdsaSignature signatureData = EcdsaSignature.of(SecpFieldElement.of(components[0]),
-                SecpFieldElement.of(components[1]));
+                SecpFieldElement.of(s));
         return SecpResult.ok(signatureData);
+    }
+
+    private BigInteger canonicalize(BigInteger s) {
+        return s.compareTo(HALF_CURVE_ORDER) <= 0
+                ? s
+                : BC_CURVE.getN().subtract(s);
     }
 
     @Override

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -168,7 +168,7 @@ public class Bouncy256k1 implements Secp256k1 {
 
     @Override
     public byte[] ecdsaSignatureSerializeCompact(EcdsaSignature sig) {
-        return sig.bytes();
+        return sig.serializeCompact();
     }
 
     // TODO: Return SecpResult.err when parsing fails

--- a/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
+++ b/secp-examples-java/src/main/java/org/bitcoinj/secp/examples/Ecdsa.java
@@ -58,7 +58,7 @@ public class Ecdsa {
 
             /* Deserialize the signature. This will return empty if the signature can't be parsed correctly. */
             EcdsaSignature sig2 = secp.ecdsaSignatureParseCompact(serializedSignature).get();
-            assert(Arrays.equals(sig.bytes(), sig2.bytes()));
+            assert(Arrays.equals(sig.serializeCompact(), sig2.serializeCompact()));
 
             /* Deserialize the public key. This will return empty if the public key can't be parsed correctly. */
             SecpPubKey pubkey2 = secp.ecPubKeyParse(compressedPubkey).get();

--- a/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
+++ b/secp-examples-kotlin/src/main/java/org/bitcoinj/secp/kotlin/examples/Ecdsa.kt
@@ -55,7 +55,7 @@ fun main() {
 
         /* Deserialize the signature. This will return empty if the signature can't be parsed correctly. */
         val sig2 = secp.ecdsaSignatureParseCompact(serializedSignature).get()
-        assert(sig.bytes().contentEquals(sig2.bytes()))
+        assert(sig.serializeCompact().contentEquals(sig2.serializeCompact()))
         /* Deserialize the public key. This will return empty if the public key can't be parsed correctly. */
         val pubkey2 = secp.ecPubKeyParse(compressedPubkey).get()
         assert(pubkey.w == pubkey2.w)

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -322,7 +322,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
 
     @Override
     public byte[] ecdsaSignatureSerializeCompact(EcdsaSignature sig) {
-        return sig.bytes();
+        return sig.serializeCompact();
     }
 
     @Override
@@ -342,7 +342,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         SecpResult<MemorySegment> parsedPubKey = pubKeyParse(pubKey);
         if (parsedPubKey instanceof SecpResult.Err<MemorySegment> err) return SecpResult.err(err.code());
         int return_val = secp256k1_h.secp256k1_ecdsa_verify(ctx,
-                arena.allocateFrom(JAVA_BYTE, sig.bytes()),
+                arena.allocateFrom(JAVA_BYTE, sig.serializeCompact()),
                 msg_hash,
                 parsedPubKey.get());
         return SecpResult.ok(return_val == 1);

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -311,13 +311,15 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
          * Signing with a valid context, verified secret key
          * and the default nonce function should never fail. */
         MemorySegment msg_hash = arena.allocateFrom(JAVA_BYTE, msg_hash_data);
-        MemorySegment sig = secp256k1_ecdsa_signature.allocate(arena);
+        MemorySegment sig = secp256k1_ecdsa_signature.allocate(arena);          // internal signature format
+        MemorySegment serSigSeg = secp256k1_ecdsa_signature.allocate(arena);    // serialized signature format
         MemorySegment nullCallback =  secp256k1_h.NULL(); // Double-check this (normally you shouldn't use a NULL pointer for a null callback)
         MemorySegment nullPointer = secp256k1_h.NULL();
         MemorySegment privKeySeg = arena.allocateFrom(JAVA_BYTE, privKey.getEncoded());
         int return_val = secp256k1_h.secp256k1_ecdsa_sign(ctx, sig, msg_hash, privKeySeg, nullCallback, nullPointer);
         privKeySeg.fill((byte) 0x00);
-        return SecpResult.checked(return_val, () -> EcdsaSignature.of(sig.toArray(JAVA_BYTE)));
+        secp256k1_h.secp256k1_ecdsa_signature_serialize_compact(ctx, serSigSeg, sig);
+        return SecpResult.checked(return_val, () -> EcdsaSignature.of(serSigSeg.toArray(JAVA_BYTE)));
     }
 
     @Override
@@ -340,9 +342,12 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
          * and the default nonce function should never fail. */
         MemorySegment msg_hash = arena.allocateFrom(JAVA_BYTE, msg_hash_data);
         SecpResult<MemorySegment> parsedPubKey = pubKeyParse(pubKey);
+        MemorySegment serSigSeg =  arena.allocateFrom(JAVA_BYTE, sig.serializeCompact());
+        MemorySegment sigSeg = secp256k1_ecdsa_signature.allocate(arena);   // internal format
+        secp256k1_h.secp256k1_ecdsa_signature_parse_compact(ctx, sigSeg, serSigSeg);
         if (parsedPubKey instanceof SecpResult.Err<MemorySegment> err) return SecpResult.err(err.code());
         int return_val = secp256k1_h.secp256k1_ecdsa_verify(ctx,
-                arena.allocateFrom(JAVA_BYTE, sig.serializeCompact()),
+                sigSeg,
                 msg_hash,
                 parsedPubKey.get());
         return SecpResult.ok(return_val == 1);

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
@@ -19,10 +19,14 @@ import org.bitcoinj.secp.SecpPrivKey;
 import org.bitcoinj.secp.SecpPubKey;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.bouncy.Bouncy256k1;
+import org.bitcoinj.secp.ffm.Secp256k1Foreign;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.bitcoinj.secp.integration.SecpTestSupport.hash;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -39,5 +43,28 @@ public class EcdsaTest implements SecpTestSupport {
         EcdsaSignature sig = secp.ecdsaSign(msg_hash, privKey).get();
         boolean validSignature = secp.ecdsaVerify(sig, msg_hash, pubKey).get();
         assertTrue(validSignature);
+    }
+
+    @Test
+    void ecdsaCrossCheck() {
+        try (Secp256k1 secp1 = new Secp256k1Foreign(); Secp256k1 secp2 = new Bouncy256k1()) {
+            SecpPrivKey secKey1 = secp1.ecPrivKeyCreate();
+            SecpPubKey pubKey1 = secp1.ecPubKeyCreate(secKey1);
+
+            SecpPrivKey secKey2 = secKey1;
+            SecpPubKey pubKey2 = secp2.ecPubKeyCreate(secKey1);
+
+            assertArrayEquals(pubKey1.serialize(), pubKey2.serialize());
+
+            EcdsaSignature sig1 = secp1.ecdsaSign(msg_hash, secKey1).get();
+            EcdsaSignature sig2 = secp2.ecdsaSign(msg_hash, secKey2).get();
+
+            assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
+
+            assertTrue(secp1.ecdsaVerify(sig1, msg_hash, pubKey1).get());
+            assertTrue(secp1.ecdsaVerify(sig2, msg_hash, pubKey2).get());
+            assertTrue(secp2.ecdsaVerify(sig1, msg_hash, pubKey1).get());
+            assertTrue(secp2.ecdsaVerify(sig2, msg_hash, pubKey2).get());
+        }
     }
 }


### PR DESCRIPTION
4 commits:

1. A preliminary commit replaces `bytes()` with `serializeCompact()` in `EcdsaSignature`, `EcdsaSignatureImpl`:
2. Secp256k1Foreign: serialize/deserialize signatures properly
3. Canonicalize the S Value in Bouncy Castle ECDSA Signature
4. Add a cross-check between Bouncy Castle and libsecp/FFM.

Additional tests are coming in a separate PR.