### PR TITLE
flake.nix: add nixpkgs-unstable, use it for libsecp256k1 0.7.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/release-25.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = inputs @ { nixpkgs, ... }:
+  outputs = inputs @ { nixpkgs, nixpkgs-unstable, ... }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       forEachSystem = f: builtins.listToAttrs (map (system: {
@@ -19,10 +20,13 @@
         pkgs = import nixpkgs {
           inherit system;
         };
+        pkgs-unstable = import nixpkgs-unstable {
+          inherit system;
+        };
         jdk = pkgs.jdk25;
         graalvm = pkgs.graalvmPackages.graalvm-ce;
         sharedShellHook = ''
-            export LIBSECP_DIR="${pkgs.lib.makeLibraryPath [ pkgs.secp256k1 ]}"
+            export LIBSECP_DIR="${pkgs-unstable.lib.makeLibraryPath [ pkgs-unstable.secp256k1 ]}"
             if [[ "$(uname)" == "Darwin" ]]; then
               export DYLD_LIBRARY_PATH="$LIBSECP_DIR:$DYLD_LIBRARY_PATH"
             else
@@ -35,7 +39,7 @@
         in {
         # define default devshell, with a richer collection of tools intended for interactive development
         default = pkgs.mkShell {
-          buildInputs = with pkgs ; [ secp256k1 zlib ];
+          buildInputs = with pkgs-unstable ; [ secp256k1 zlib ];
           packages = with pkgs ; [
                 jdk                        # This JDK will be in PATH
                 # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
@@ -51,7 +55,7 @@
         };
         # define minimum devshell, with the minimum necessary to do a CI build
         minimum = pkgs.mkShell {
-          buildInputs = with pkgs ; [ secp256k1 zlib ];
+          buildInputs = with pkgs-unstable ; [ secp256k1 zlib ];
           packages = with pkgs ; [
                 graalvm                    # This JDK will be in PATH
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK


### PR DESCRIPTION
This should  be rebased after a `nix flake update` PR is merged to `master`.