### PR TITLE
ECDSA signature cleanup, SecpScalar type, etc.

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
@@ -22,20 +22,20 @@ import org.bitcoinj.secp.internal.EcdsaSignatureImpl;
  */
 public interface EcdsaSignature {
     /**
-     * Get field element R
+     * Get scalar R
      * @return R
      */
-    SecpFieldElement r();
+    SecpScalar r();
 
     /**
-     * Get field element S
+     * Get scalar S
      * @return S
      */
-    SecpFieldElement s();
+    SecpScalar s();
 
     /**
      * Serialize as a Bitcoin <i>compact signature</i>. A compact signature is  the two signature component
-     * field integers (known as {@code r} and {@code s}) serialized in-order as binary data in big-endian format.
+     * scalars (known as {@code r} and {@code s}) serialized in-order as binary data in big-endian format.
      * @return a Bitcoin compact signature
      */
     byte[] serializeCompact();
@@ -62,7 +62,7 @@ public interface EcdsaSignature {
      * @param s S
      * @return signature
      */
-    static EcdsaSignature of(SecpFieldElement r, SecpFieldElement s) {
-        return new EcdsaSignatureImpl(r,s);
+    static EcdsaSignature of(SecpScalar r, SecpScalar s) {
+        return new EcdsaSignatureImpl(r, s);
     }
 }

--- a/secp-api/src/main/java/org/bitcoinj/secp/SchnorrSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SchnorrSignature.java
@@ -22,16 +22,16 @@ import org.bitcoinj.secp.internal.SchnorrSignatureImpl;
  */
 public interface SchnorrSignature {
     /**
-     * Get field element R
+     * Get scalar R
      * @return R
      */
-    SecpFieldElement r();
+    SecpScalar r();
 
     /**
-     * Get field element S
+     * Get scalar S
      * @return S
      */
-    SecpFieldElement s();
+    SecpScalar s();
 
     /**
      * Serialize to 64-byte raw format in a {@code byte[]}.

--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -58,6 +58,10 @@ public interface Secp256k1 extends Closeable {
      * {@link BigInteger} instead.
      */
     BigInteger P = new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F", 16);
+    /**
+     * The prime {@code N}, that represents the order of the generator point, i.e. the number of points on the curve.
+     */
+    BigInteger N = new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16);
     /** The generator point {@code G} (also known as <i>base point</i>) for secp256k1. */
     SecpPoint.Uncompressed G = SecpPointUncompressed.of(
             new BigInteger("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798", 16),  // G.x
@@ -71,7 +75,7 @@ public interface Secp256k1 extends Closeable {
     /** The secp256k1 domain parameters definition using the standard Java type */
     ECParameterSpec EC_PARAMS = new ECParameterSpec(CURVE,
         G.toECPoint(),  // Base point G
-        new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16),  // Order n
+        N,              // Order n
         1);             // Cofactor h
 
     /**

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpScalar.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpScalar.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp;
+
+import java.math.BigInteger;
+
+public interface SecpScalar {
+    BigInteger MIN_VALUE = BigInteger.ONE;
+    BigInteger MAX_VALUE = Secp256k1.N.subtract(BigInteger.ONE);
+
+    /**
+     * Get the scalar as a {@code BigInteger}
+     * @return scalar value
+     */
+    BigInteger toBigInteger();
+
+    /**
+     * Check if an integer is in the inclusive range {@code 1} to {@code N - 1}, where {@code N} is
+     * the order of the SECG P256K1 generator point.
+     *
+     * @param e A possible scalar to validate
+     * @return true if valid
+     */
+    static boolean isInRange(BigInteger e) {
+        return e.signum() > 0 && e.compareTo(MAX_VALUE) <= 0;
+    }
+
+    /**
+     * Throw {@link IllegalArgumentException} if an integer is not in the inclusive range {@code 1} to {@code N - 1}, where {@code N} is
+     * the order of the SECG P256K1 generator point.
+     *
+     * @param e unvalidated integer
+     * @return a validated integer
+     */
+    static BigInteger checkInRange(BigInteger e) {
+        if (!isInRange(e)) {
+            throw new IllegalArgumentException("BigInteger is not a valid SecpScalar: " + e);
+        }
+        return e;
+    }
+
+    byte[] serialize();
+}

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
@@ -15,8 +15,8 @@
  */
 package org.bitcoinj.secp.internal;
 
-import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.SecpScalar;
 
 import java.util.Arrays;
 
@@ -24,29 +24,34 @@ import java.util.Arrays;
  * Default/Internal implementation of {@link EcdsaSignature}
  */
 public class EcdsaSignatureImpl implements EcdsaSignature {
-    private final SecpFieldElement r;
-    private final SecpFieldElement s;
+    private final SecpScalarImpl r;
+    private final SecpScalarImpl s;
 
-    public EcdsaSignatureImpl(SecpFieldElement r, SecpFieldElement s) {
+    public EcdsaSignatureImpl(SecpScalarImpl r, SecpScalarImpl s) {
         this.r = r;
         this.s = s;
+    }
+
+    public EcdsaSignatureImpl(SecpScalar r, SecpScalar s) {
+        this.r = new SecpScalarImpl(r.serialize());
+        this.s = new SecpScalarImpl(s.serialize());
     }
 
     public EcdsaSignatureImpl(byte[] signature) {
         if (signature.length != 64) {
             throw new IllegalArgumentException("Sig Not 64 bytes");
         }
-        this.r = SecpFieldElement.of(Arrays.copyOfRange(signature, 0, 32));
-        this.s = SecpFieldElement.of(Arrays.copyOfRange(signature, 32, 64));
+        this.r = new SecpScalarImpl(Arrays.copyOfRange(signature, 0, 32));
+        this.s = new SecpScalarImpl(Arrays.copyOfRange(signature, 32, 64));
     }
 
     @Override
-    public SecpFieldElement r() {
+    public SecpScalarImpl r() {
         return r;
     }
 
     @Override
-    public SecpFieldElement s() {
+    public SecpScalarImpl s() {
         return s;
     }
 

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SchnorrSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SchnorrSignatureImpl.java
@@ -16,7 +16,7 @@
 package org.bitcoinj.secp.internal;
 
 import org.bitcoinj.secp.SchnorrSignature;
-import org.bitcoinj.secp.SecpFieldElement;
+import org.bitcoinj.secp.SecpScalar;
 
 import java.util.Arrays;
 
@@ -24,29 +24,24 @@ import java.util.Arrays;
  * A secp256k1 Schnorr signature.
  */
 public class SchnorrSignatureImpl implements SchnorrSignature, ByteArray {
-    private final SecpFieldElement r;
-    private final SecpFieldElement s;
-
-    public SchnorrSignatureImpl(SecpFieldElement r, SecpFieldElement s) {
-        this.r = r;
-        this.s = s;
-    }
+    private final SecpScalar r;
+    private final SecpScalar s;
 
     public SchnorrSignatureImpl(byte[] signature) {
         if (signature.length != 64) {
             throw new IllegalArgumentException("Sig Not 64 bytes");
         }
-        this.r = SecpFieldElement.of(Arrays.copyOfRange(signature, 0, 32));
-        this.s = SecpFieldElement.of(Arrays.copyOfRange(signature, 32, 64));
+        this.r = new SecpScalarImpl(Arrays.copyOfRange(signature, 0, 32));
+        this.s = new SecpScalarImpl(Arrays.copyOfRange(signature, 32, 64));
     }
 
     @Override
-    public SecpFieldElement r() {
+    public SecpScalar r() {
         return r;
     }
 
     @Override
-    public SecpFieldElement s() {
+    public SecpScalar s() {
         return s;
     }
 

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPrivKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPrivKeyImpl.java
@@ -37,11 +37,11 @@ public class SecpPrivKeyImpl implements SecpPrivKey {
      * @param bytes (will not be defensively copied)
      */
     public SecpPrivKeyImpl(byte[] bytes) {
-        privKeyBytes = SecpFieldElementImpl.checkInRange(bytes);
+        privKeyBytes = SecpScalarImpl.checkInRange(bytes);
     }
 
     public SecpPrivKeyImpl(BigInteger privKey) {
-        this.privKeyBytes = SecpFieldElementImpl.integerTo32Bytes(privKey);
+        this.privKeyBytes = SecpScalarImpl.integerTo32Bytes(privKey);
     }
 
     @Override

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpScalarImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpScalarImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.internal;
+
+import org.bitcoinj.secp.SecpScalar;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+
+public class SecpScalarImpl implements SecpScalar {
+    static final byte[] MAX_VALUE_BYTES = integerTo32Bytes(MAX_VALUE);
+
+    /** scalar value as a 32-byte big-endian byte array */
+    private final byte[] value;
+
+    public SecpScalarImpl(byte[] bytes) {
+        value = checkInRange(bytes);
+    }
+
+    public SecpScalarImpl(BigInteger i) {
+        value = SecpScalarImpl.integerTo32Bytes(i);
+    }
+
+    @Override
+    public BigInteger toBigInteger() {
+        return ByteArray.toInteger(value);
+    }
+
+    @Override
+    public byte[] serialize() {
+        return value.clone();
+    }
+
+    static boolean isInRange(byte[] e) {
+        if (e.length != 32) {
+            throw new IllegalArgumentException("SecpScalar must have 32 bytes, found : " + e.length);
+        }
+        return !MessageDigest.isEqual(e, UInt256.ZERO_VALUE) && ByteUtils.compareUnsigned(e, MAX_VALUE_BYTES) <= 0;
+    }
+
+    // TODO: constant-time implementation?
+    /**
+     * Throw {@link IllegalArgumentException} if the byte array is not the length.
+     * <p>
+     * <b>NOTE:</b> We are not currently validating for value less than {@code N}
+     * @param e unvalidated integer ({@code byte[]} format)
+     * @return a validated integer ({@code byte[]} format)
+     */
+    static byte[] checkInRange(byte[] e) {
+        if (e.length != 32) {
+            throw new IllegalArgumentException("SecpScalar must have 32 bytes, found : " + e.length);
+        }
+        if (!isInRange(e)) {
+            throw new IllegalArgumentException("byte[] is not a valid SecpScalar: " + ByteUtils.toHexString(e));
+        }
+        return e;
+    }
+
+    /**
+     * Convert a BigInteger to a fixed-length byte array verifying it's a valid P256k1 scalar.
+     * @param i an unsigned BigInteger containing a valid Secp256k1 scalar value
+     * @return a 32-byte, big-endian, unsigned, in-range integer value
+     */
+    public static byte[] integerTo32Bytes(BigInteger i) {
+        return UInt256.integerTo32Bytes(SecpScalar.checkInRange(i));
+    }
+}

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/UInt256.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/UInt256.java
@@ -27,6 +27,7 @@ public interface UInt256 {
     BigInteger MIN_VALUE = BigInteger.ZERO;
     /** The maximum unsigned 32-byte / 256-bit value. ({@code 2^256 - 1}) */
     BigInteger MAX_VALUE = BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE);
+    byte[] ZERO_VALUE = new byte[32];
 
     /**
      * Convert a BigInteger to a 32-byte fixed-length byte array (UInt256).

--- a/secp-api/src/test/java/org/bitcoinj/secp/internal/SecpPrivKeyImplTest.java
+++ b/secp-api/src/test/java/org/bitcoinj/secp/internal/SecpPrivKeyImplTest.java
@@ -15,77 +15,71 @@
  */
 package org.bitcoinj.secp.internal;
 
-import org.junit.jupiter.api.Assertions;
+import org.bitcoinj.secp.SecpScalar;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
 import java.math.BigInteger;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.bitcoinj.secp.Secp256k1.N;
+import static org.bitcoinj.secp.Secp256k1.P;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Tests for UInt256Test
- */
-public class UInt256Test {
-    static BigInteger P = new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F", 16);
-    static List<BigInteger> inRangeInts = List.of(
-            BigInteger.ZERO,
-            BigInteger.ONE,
-            P.subtract(BigInteger.ONE),
-            P,
-            UInt256.MAX_VALUE);
-    static List<BigInteger> outOfRangeInts = List.of(
-            BigInteger.ONE.negate(),
-            UInt256.MAX_VALUE.add(BigInteger.ONE));
+public class SecpPrivKeyImplTest {
+    static List<BigInteger> inRangeScalarInts = List.of(BigInteger.ONE, N.subtract(BigInteger.ONE));
+    static List<BigInteger> outOfRangeScalarInts = List.of(BigInteger.ONE.negate(), BigInteger.ZERO, N, P);
 
-    @FieldSource("inRangeInts")
+    @FieldSource("inRangeScalarInts")
     @ParameterizedTest(name = "n: {0}")
     void testIsInRange(BigInteger n) {
-        assertTrue(UInt256.isInRange(n));
+        assertTrue(SecpScalar.isInRange(n));
+        assertTrue(SecpScalarImpl.isInRange(UInt256.integerTo32Bytes(n)));
     }
 
-    @FieldSource("outOfRangeInts")
+    @FieldSource("outOfRangeScalarInts")
     @ParameterizedTest(name = "n: {0}")
     void testIsOutOfRange(BigInteger n) {
-        assertFalse(UInt256.isInRange(n));
+        assertFalse(SecpScalar.isInRange(n));
+        if (UInt256.isInRange(n)) {
+            // Integer is a valid UInt256, isInRange should report `false`
+            byte[] bytes = UInt256.integerTo32Bytes(n);
+            assertFalse(SecpScalarImpl.isInRange(bytes));
+        } else {
+            // Integer is not a valid UInt256, attempt to convert should throw
+            assertThrows(IllegalArgumentException.class,
+                    () -> UInt256.integerTo32Bytes(n)
+            );
+        }
     }
 
-    @FieldSource("inRangeInts")
+    @FieldSource("inRangeScalarInts")
     @ParameterizedTest(name = "n: {0}")
     void testCheckInRangeValid(BigInteger n) {
         assertDoesNotThrow(
-            () -> UInt256.checkInRange(n)
+                () -> SecpScalar.checkInRange(n)
         );
-        assertEquals(n, UInt256.checkInRange(n));
+        assertEquals(n, SecpScalar.checkInRange(n));
+        byte[] bytes = UInt256.integerTo32Bytes(n);
+        assertDoesNotThrow(
+                () -> SecpScalarImpl.checkInRange(bytes)
+        );
+        assertEquals(bytes, SecpScalarImpl.checkInRange(bytes));
     }
 
-    @FieldSource("outOfRangeInts")
+    @FieldSource("outOfRangeScalarInts")
     @ParameterizedTest(name = "n: {0}")
     void testCheckInRangeInvalid(BigInteger n) {
         assertThrows(IllegalArgumentException.class,
-            () -> UInt256.checkInRange(n)
+                () -> SecpScalar.checkInRange(n)
         );
-    }
-
-    @FieldSource("inRangeInts")
-    @ParameterizedTest(name = "n: {0}")
-    void testIntToBytesValid(BigInteger n) {
-        assertDoesNotThrow(
-                () -> UInt256.integerTo32Bytes(n)
-        );
-    }
-
-    @FieldSource("outOfRangeInts")
-    @ParameterizedTest(name = "n: {0}")
-    void testIntToBytesInvalid(BigInteger n) {
+        byte[] bytes = n.toByteArray();
         assertThrows(IllegalArgumentException.class,
-                () -> UInt256.integerTo32Bytes(n)
+                () -> SecpScalarImpl.checkInRange(bytes)
         );
     }
 }

--- a/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
+++ b/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
@@ -27,6 +27,7 @@ import org.bitcoinj.secp.SecpXOnlyPubKey;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.internal.SecpFieldElementImpl;
 import org.bitcoinj.secp.internal.SecpPubKeyImpl;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
 import org.bitcoinj.secp.internal.UInt256;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -116,7 +117,7 @@ public class AddressTest {
             BigInteger internalPubKey = new BigInteger("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d", 16);
             byte[] compressed = new byte[33];
             compressed[0] = 0x02;
-            byte[] xbytes = SecpFieldElementImpl.integerTo32Bytes(internalPubKey);
+            byte[] xbytes = SecpScalarImpl.integerTo32Bytes(internalPubKey);
             System.arraycopy(xbytes, 0, compressed, 1, 32);
             ECKey ecKey = ECKey.fromPublicOnly(compressed);
             SecpPubKey pubkey = BC.toP256K1PubKey(ecKey.getPubKeyPoint());

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -16,7 +16,6 @@
 package org.bitcoinj.secp.bouncy;
 
 import org.bitcoinj.secp.EcdhSharedSecret;
-import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpKeyPair;
 import org.bitcoinj.secp.SecpPubKey;
 import org.bitcoinj.secp.SecpPrivKey;
@@ -27,6 +26,7 @@ import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.EcdsaSignature;
 import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.SecpKeyPairImpl;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.digests.SHA256Digest;
@@ -173,8 +173,8 @@ public class Bouncy256k1 implements Secp256k1 {
     // Convert and canonicalize signature
     private EcdsaSignature ecdsaSignature(BigInteger[] components) {
         return EcdsaSignature.of(
-                SecpFieldElement.of(components[0]),
-                SecpFieldElement.of(canonicalize(components[1]))
+                new SecpScalarImpl(components[0]),
+                new SecpScalarImpl(canonicalize(components[1]))
         );
     }
 

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -159,7 +159,6 @@ public class Bouncy256k1 implements Secp256k1 {
         throw new UnsupportedOperationException();
     }
 
-    // TODO: Add constructor to create SignatureData from r and s
     @Override
     public SecpResult<EcdsaSignature> ecdsaSign(byte[] msg_hash_data, SecpPrivKey privKey) {
         BigInteger privateKeyForSigning = privKey.getS();
@@ -168,10 +167,15 @@ public class Bouncy256k1 implements Secp256k1 {
         ECPrivateKeyParameters bouncyPrivKey = new ECPrivateKeyParameters(privateKeyForSigning, BC_CURVE);
         signer.init(true, bouncyPrivKey);
         BigInteger[] components = signer.generateSignature(msg_hash_data);
-        BigInteger s = canonicalize(components[1]);
-        EcdsaSignature signatureData = EcdsaSignature.of(SecpFieldElement.of(components[0]),
-                SecpFieldElement.of(s));
-        return SecpResult.ok(signatureData);
+        return SecpResult.ok(ecdsaSignature(components));
+    }
+
+    // Convert and canonicalize signature
+    private EcdsaSignature ecdsaSignature(BigInteger[] components) {
+        return EcdsaSignature.of(
+                SecpFieldElement.of(components[0]),
+                SecpFieldElement.of(canonicalize(components[1]))
+        );
     }
 
     private BigInteger canonicalize(BigInteger s) {

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -63,7 +63,7 @@ public class Bouncy256k1 implements Secp256k1 {
      * Equal to CURVE.getN().shiftRight(1), used for canonicalizing the S value of a signature. If you aren't
      * sure what this is about, you can ignore it.
      */
-    private static final BigInteger HALF_CURVE_ORDER;
+    static final BigInteger HALF_CURVE_ORDER;
 
     private static final SecureRandom secureRandom;
 
@@ -178,7 +178,7 @@ public class Bouncy256k1 implements Secp256k1 {
         );
     }
 
-    private BigInteger canonicalize(BigInteger s) {
+    BigInteger canonicalize(BigInteger s) {
         return s.compareTo(HALF_CURVE_ORDER) <= 0
                 ? s
                 : BC_CURVE.getN().subtract(s);

--- a/secp-bouncy/src/test/java/org/bitcoinj/secp/bouncy/Bouncy256k1Test.java
+++ b/secp-bouncy/src/test/java/org/bitcoinj/secp/bouncy/Bouncy256k1Test.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023-2025 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.bouncy;
+
+import org.bitcoinj.secp.Secp256k1;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+import static java.math.BigInteger.ONE;
+import static org.bitcoinj.secp.Secp256k1.N;
+import static org.bitcoinj.secp.bouncy.Bouncy256k1.HALF_CURVE_ORDER;
+
+public class Bouncy256k1Test {
+    Bouncy256k1 secp = new Bouncy256k1();
+
+    final static List<Map.Entry<BigInteger, BigInteger>> canonPairs = Map.of(
+        ONE, ONE,
+        HALF_CURVE_ORDER.subtract(ONE), HALF_CURVE_ORDER.subtract(ONE),
+        HALF_CURVE_ORDER, HALF_CURVE_ORDER,
+        HALF_CURVE_ORDER.add(ONE), HALF_CURVE_ORDER,
+        N.subtract(ONE), ONE
+    ).entrySet().stream().toList();
+
+    @ParameterizedTest
+    @FieldSource("canonPairs")
+    void testCanonicalize(Map.Entry<BigInteger, BigInteger> pair) {
+        BigInteger canonicalized = secp.canonicalize(pair.getKey());
+        Assertions.assertEquals(pair.getValue(), canonicalized);
+    }
+}

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -20,6 +20,7 @@ import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpKeyPair;
 import org.bitcoinj.secp.SecpPubKey;
 import org.bitcoinj.secp.SecpResult;
+import org.bitcoinj.secp.SecpScalar;
 import org.bitcoinj.secp.SecpXOnlyPubKey;
 import org.bitcoinj.secp.SecpPrivKey;
 import org.bitcoinj.secp.SchnorrSignature;
@@ -36,6 +37,7 @@ import org.bitcoinj.secp.ffm.jextract.secp256k1_keypair;
 import org.bitcoinj.secp.ffm.jextract.secp256k1_pubkey;
 import org.bitcoinj.secp.ffm.jextract.secp256k1_xonly_pubkey;
 import org.bitcoinj.secp.internal.SchnorrSignatureImpl;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
 import org.bitcoinj.secp.internal.SecpXOnlyPubKeyImpl;
 
 import java.lang.foreign.Arena;
@@ -200,7 +202,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     @Override
     public SecpPubKey ecPubKeyTweakMul(SecpPubKey pubKey, BigInteger scalarMultiplier) {
         MemorySegment pubKeySeg = pubKeyParse(pubKey).get();
-        byte[] tweakBytes = SecpFieldElementImpl.integerTo32Bytes(scalarMultiplier);
+        byte[] tweakBytes = SecpScalarImpl.integerTo32Bytes(scalarMultiplier);
         MemorySegment tweakSeg = arena.allocateFrom(JAVA_BYTE, tweakBytes);
         int return_val = secp256k1_h.secp256k1_ec_pubkey_tweak_mul(ctx, pubKeySeg, tweakSeg);
         if (return_val != 1) {


### PR DESCRIPTION
4 commits:

* Bouncy256k1: extract ecdsaSignature conversion/canonicalization method
* Secp256k1: add constant N for order of generator point
* Bouncy256k1Test: add tests for Bouncy Castle S canonicalization
* add SecpScalar, SecpScalarImpl types for scalars