### PR TITLE
Bouncy256k1: return error in ecdsaSignatureParseCompact

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -185,10 +185,13 @@ public class Bouncy256k1 implements Secp256k1 {
         return sig.serializeCompact();
     }
 
-    // TODO: Return SecpResult.err when parsing fails
     @Override
     public SecpResult<EcdsaSignature> ecdsaSignatureParseCompact(byte[] serialized_signature) {
-        return SecpResult.ok(EcdsaSignature.of(serialized_signature));
+        try {
+            return SecpResult.ok(EcdsaSignature.of(serialized_signature));
+        } catch (IllegalArgumentException iae) {
+            return SecpResult.err(0);
+        }
     }
 
     @Override


### PR DESCRIPTION
This should return an error (not throw IllegalArgumentException) when given an invalid byte[] argument.