### PR TITLE
SecpPubKey: extend SecpPoint.Uncompressed

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -175,7 +175,7 @@ public interface Secp256k1 extends Closeable {
      * @param scalarMultiplier scalar multiplier
      * @return the product
      */
-    SecpPubKey ecPubKeyTweakMul(SecpPubKey pubKey, BigInteger scalarMultiplier);
+    SecpPubKey ecPubKeyTweakMul(SecpPoint.Uncompressed pubKey, BigInteger scalarMultiplier);
 
     /**
      * Combine two public keys by adding them.
@@ -183,7 +183,7 @@ public interface Secp256k1 extends Closeable {
      * @param key2 second key
      * @return the sum
      */
-    SecpPubKey ecPubKeyCombine(SecpPubKey key1, SecpPubKey key2);
+    SecpPubKey ecPubKeyCombine(SecpPoint.Uncompressed key1, SecpPoint.Uncompressed key2);
 
     /**
      * Serialize a public key

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
@@ -21,10 +21,14 @@ import org.bitcoinj.secp.internal.SecpPointUncompressed;
 import java.security.spec.ECPoint;
 
 /**
- * A P256K1 point -- either {@link Compressed}, {@link Uncompressed}, or {@link Infinity}. Implementations of this interface
- * <i>need not</i> be subclasses of {@link java.security.spec.ECPoint}. {@code ECPoint} is a concrete class
- * and uses {@link java.math.BigInteger} internally. {@code SecpPoint} uses
- * {@link SecpFieldElement} to represent point coordinates. If you need a type that
+ * A P256K1 point -- either {@link Compressed}, {@link Uncompressed}, or {@link Infinity}.
+ * <p>
+ * {@link SecpPubKey} implements {@code SecpPoint.Uncompressed} and Java's {@link java.security.interfaces.ECPublicKey}
+ * interface.
+ * <p>
+ * Implementations of this interface <i>need not</i> be subclasses of {@link java.security.spec.ECPoint}.
+ * {@code ECPoint} is a concrete class and uses {@link java.math.BigInteger} internally.
+ * {@code SecpPoint} may use {@link SecpFieldElement} to represent point coordinates. If you need a type that
  * is both a {@code SecpPoint} and a {@code ECPoint}, use {@link SecpECPoint}.
  */
 public interface SecpPoint {

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
@@ -23,9 +23,9 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 
 /**
- * A valid secp256k1 Public Key that is a subclass of {@link ECPublicKey}
+ * A valid secp256k1 Public Key that is a subclass of {@link ECPublicKey}.
  */
-public interface SecpPubKey extends ECPublicKey {
+public interface SecpPubKey extends ECPublicKey, SecpPoint.Uncompressed {
     /**
      * Return associated cryptographic algorithm. This implements the {@link java.security.Key} interface.
      * @return string indicating algorithm

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
@@ -15,6 +15,7 @@
  */
 package org.bitcoinj.secp.internal;
 
+import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpPoint;
 import org.bitcoinj.secp.SecpPubKey;
 
@@ -62,5 +63,25 @@ public class SecpPubKeyImpl implements SecpPubKey {
     @Override
     public String toString() {
         return ByteUtils.toHexString(point.serialize());
+    }
+
+    @Override
+    public SecpFieldElement y() {
+        return point.y();
+    }
+
+    @Override
+    public Compressed compress() {
+        return point.compress();
+    }
+
+    @Override
+    public SecpFieldElement x() {
+        return point.x();
+    }
+
+    @Override
+    public boolean isOdd() {
+        return point.isOdd();
     }
 }

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -17,6 +17,7 @@ package org.bitcoinj.secp.bouncy;
 
 import org.bitcoinj.secp.EcdhSharedSecret;
 import org.bitcoinj.secp.SecpKeyPair;
+import org.bitcoinj.secp.SecpPoint;
 import org.bitcoinj.secp.SecpPubKey;
 import org.bitcoinj.secp.SecpPrivKey;
 import org.bitcoinj.secp.SecpResult;
@@ -126,16 +127,16 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public SecpPubKey ecPubKeyTweakMul(SecpPubKey pubKey, BigInteger scalarMultiplier) {
-        ECPoint pubKeyBC = BC_CURVE.createPoint(pubKey.getW().getAffineX(), pubKey.getW().getAffineY());
+    public SecpPubKey ecPubKeyTweakMul(SecpPoint.Uncompressed pubKey, BigInteger scalarMultiplier) {
+        ECPoint pubKeyBC = BC_CURVE.createPoint(pubKey.x().toBigInteger(), pubKey.y().toBigInteger());
         ECPoint pub = new FixedPointCombMultiplier().multiply(pubKeyBC, scalarMultiplier).normalize();
         return BC.toSecpPubKey(pub);
     }
 
     @Override
-    public SecpPubKey ecPubKeyCombine(SecpPubKey key1, SecpPubKey key2) {
-        ECPoint pubKey1BC = BC_CURVE.createPoint(key1.getW().getAffineX(), key1.getW().getAffineY());
-        ECPoint pubKey2BC = BC_CURVE.createPoint(key2.getW().getAffineX(), key2.getW().getAffineY());
+    public SecpPubKey ecPubKeyCombine(SecpPoint.Uncompressed  key1, SecpPoint.Uncompressed  key2) {
+        ECPoint pubKey1BC = BC_CURVE.createPoint(key1.x().toBigInteger(), key1.y().toBigInteger());
+        ECPoint pubKey2BC = BC_CURVE.createPoint(key2.x().toBigInteger(), key2.y().toBigInteger());
         ECPoint result = pubKey1BC.add(pubKey2BC);
         return BC.toSecpPubKey(result);
     }

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -18,6 +18,7 @@ package org.bitcoinj.secp.ffm;
 import org.bitcoinj.secp.EcdhSharedSecret;
 import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpKeyPair;
+import org.bitcoinj.secp.SecpPoint;
 import org.bitcoinj.secp.SecpPubKey;
 import org.bitcoinj.secp.SecpResult;
 import org.bitcoinj.secp.SecpXOnlyPubKey;
@@ -200,7 +201,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     @Override
-    public SecpPubKey ecPubKeyTweakMul(SecpPubKey pubKey, BigInteger scalarMultiplier) {
+    public SecpPubKey ecPubKeyTweakMul(SecpPoint.Uncompressed pubKey, BigInteger scalarMultiplier) {
         MemorySegment pubKeySeg = pubKeyParse(pubKey).get();
         byte[] tweakBytes = SecpScalarImpl.integerTo32Bytes(scalarMultiplier);
         MemorySegment tweakSeg = arena.allocateFrom(JAVA_BYTE, tweakBytes);
@@ -212,7 +213,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     @Override
-    public SecpPubKey ecPubKeyCombine(SecpPubKey key1, SecpPubKey key2) {
+    public SecpPubKey ecPubKeyCombine(SecpPoint.Uncompressed key1, SecpPoint.Uncompressed key2) {
         MemorySegment resultKeySeg = secp256k1_pubkey.allocate(arena);
         MemorySegment ins = arena.allocate(C_POINTER, 2);
         ins.setAtIndex(C_POINTER, 0, pubKeyParse(key1).get());
@@ -299,8 +300,8 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return SecpResult.ok(SecpXOnlyPubKeyImpl.ofVerifiedBytes(serializedXOnly.toArray(JAVA_BYTE)));
     }
 
-    private SecpResult<MemorySegment> pubKeyParse(SecpPubKey pubKeyData) {
-        MemorySegment input = arena.allocateFrom(JAVA_BYTE, pubKeyData.getEncoded()); // 65 byte, uncompressed format
+    private SecpResult<MemorySegment> pubKeyParse(SecpPoint.Uncompressed pubKeyData) {
+        MemorySegment input = arena.allocateFrom(JAVA_BYTE, pubKeyData.serialize()); // 65 byte, uncompressed format
         MemorySegment pubkey = secp256k1_pubkey.allocate(arena);
         int return_val = secp256k1_h.secp256k1_ec_pubkey_parse(ctx, pubkey, input, input.byteSize());
         return SecpResult.checked(return_val, () -> pubkey);


### PR DESCRIPTION
There are methods in the API such as ecPubKeyTweakMul and ecPubKeyCombine that should be able to take SecpPoint.Uncompressed. This change seems to make things simpler and more flexible.

It also allows deprecation/removal of the SecpPubKey.point() getter.