### PR TITLE
Change `r` in `SchnorrSignature` to be a `SecpFieldElement`

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/SchnorrSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SchnorrSignature.java
@@ -16,6 +16,7 @@
 package org.bitcoinj.secp;
 
 import org.bitcoinj.secp.internal.SchnorrSignatureImpl;
+import org.bitcoinj.secp.internal.SecpFieldElementImpl;
 
 /**
  * A secp256k1 Schnorr signature.
@@ -25,7 +26,7 @@ public interface SchnorrSignature {
      * Get scalar R
      * @return R
      */
-    SecpScalar r();
+    SecpFieldElement r();
 
     /**
      * Get scalar S

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SchnorrSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SchnorrSignatureImpl.java
@@ -16,6 +16,7 @@
 package org.bitcoinj.secp.internal;
 
 import org.bitcoinj.secp.SchnorrSignature;
+import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpScalar;
 
 import java.util.Arrays;
@@ -24,19 +25,19 @@ import java.util.Arrays;
  * A secp256k1 Schnorr signature.
  */
 public class SchnorrSignatureImpl implements SchnorrSignature, ByteArray {
-    private final SecpScalar r;
+    private final SecpFieldElement r;
     private final SecpScalar s;
 
     public SchnorrSignatureImpl(byte[] signature) {
         if (signature.length != 64) {
             throw new IllegalArgumentException("Sig Not 64 bytes");
         }
-        this.r = new SecpScalarImpl(Arrays.copyOfRange(signature, 0, 32));
+        this.r = new SecpFieldElementImpl(Arrays.copyOfRange(signature, 0, 32));
         this.s = new SecpScalarImpl(Arrays.copyOfRange(signature, 32, 64));
     }
 
     @Override
-    public SecpScalar r() {
+    public SecpFieldElement r() {
         return r;
     }
 


### PR DESCRIPTION
The `r` in a Schnorr signature represents the x-coordinate of the public nonce (a point). We won't be able to parse valid schnorr signatures if they have an `r` greater than `n` but less than `p` (although the chances of selecting such a nonce are 1 in 2^127 ~= 0).