### PR TITLE
Secp256k1: add ecPubKeyFromXOnly(), WitnessMaker: use ecPubKeyFromXOnly(), AddressTest: use WitnessMaker

### DIFF
--- a/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
+++ b/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
@@ -19,14 +19,10 @@ import org.bitcoinj.base.Address;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.SegwitAddress;
-import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.secp.SecpKeyPair;
-import org.bitcoinj.secp.SecpPubKey;
 import org.bitcoinj.secp.SecpPrivKey;
 import org.bitcoinj.secp.SecpXOnlyPubKey;
 import org.bitcoinj.secp.Secp256k1;
-import org.bitcoinj.secp.internal.SecpPubKeyImpl;
-import org.bitcoinj.secp.internal.SecpScalarImpl;
 import org.bitcoinj.secp.internal.UInt256;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -39,7 +35,6 @@ import java.util.HexFormat;
 import java.util.List;
 
 import static org.bitcoinj.secp.Secp256k1.ProviderId.BOUNCY_CASTLE;
-import static org.bitcoinj.secp.bitcoinj.WitnessMaker.calcTweak;
 
 /**
  * Work-in-progress experiments to create Taproot addresses from private keys.
@@ -97,21 +92,12 @@ public class AddressTest {
     void createAddressTest2() throws Exception {
         Address tapRootAddress;
         try (Secp256k1 secp = Secp256k1.get()) {
+            WitnessMaker maker = new WitnessMaker(secp);
             BigInteger internalPubKey = new BigInteger("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d", 16);
-            byte[] compressed = new byte[33];
-            compressed[0] = 0x02;
-            byte[] xbytes = SecpScalarImpl.integerTo32Bytes(internalPubKey);
-            System.arraycopy(xbytes, 0, compressed, 1, 32);
-            ECKey ecKey = ECKey.fromPublicOnly(compressed);
-            SecpPubKey pubkey = secp.ecPubKeyParse(compressed).get();
             // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
             // We need a Bouncy Castle Implementation first
             SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(UInt256.integerTo32Bytes(internalPubKey)).get();
-            BigInteger tweakInt = calcTweak(xOnlyKey);
-            SecpPubKey G = new SecpPubKeyImpl(Secp256k1.G);
-            SecpPubKey P2 = secp.ecPubKeyTweakMul(G, tweakInt);
-            SecpPubKey Q = secp.ecPubKeyCombine(pubkey, P2);
-            byte[] witnessProgram = Q.xOnly().serialize();
+            byte[] witnessProgram = maker.calcWitnessProgram(xOnlyKey);
             tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
         }
         System.out.println(tapRootAddress);

--- a/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
+++ b/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
@@ -26,60 +26,61 @@ import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.internal.UInt256;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.FieldSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigInteger;
 import java.util.HexFormat;
 import java.util.List;
-
-import static org.bitcoinj.secp.Secp256k1.ProviderId.BOUNCY_CASTLE;
+import java.util.stream.Stream;
 
 /**
  * Work-in-progress experiments to create Taproot addresses from private keys.
  * Needs to be rewritten using known test vectors.
  */
+@ParameterizedClass
+@MethodSource("secpImplementations")
 public class AddressTest {
+    /**
+     * Return an instance of {@link Secp256k1} for all known providers.
+     * @return stream of all providers
+     */
+    static Stream<Secp256k1> secpImplementations() {
+        return Secp256k1.all().map(Secp256k1.Provider::get);
+    }
+
     final static Network network = BitcoinNetwork.MAINNET;
+    private final Secp256k1 secp;
+
+    /// @param secp injected Secp256k1 implementation to test
+    AddressTest(Secp256k1 secp) {
+        this.secp = secp;
+    }
+
     @FieldSource("keyAddressArgs")
     @ParameterizedTest(name = "key {0} -> Address {1}")
     void createAddressTest(BigInteger key, String address) throws Exception {
         Address tapRootAddress;
-        try (Secp256k1 secp = Secp256k1.getById(BOUNCY_CASTLE)) {
-            SecpKeyPair keyPair = secp.ecKeyPairCreate(SecpPrivKey.of(key));
-            WitnessMaker maker = new WitnessMaker(secp);
-            byte[] witnessProgram = maker.calcWitnessProgram(keyPair.publicKey());
-            tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
-        }
-        Assertions.assertEquals(address, tapRootAddress.toString());
-    }
-
-    @FieldSource("keyAddressArgs")
-    @ParameterizedTest(name = "key {0} -> Address {1}")
-    void createAddressTestBouncy(BigInteger key, String address) throws Exception {
-        Address tapRootAddress;
-        try (Secp256k1 secp = Secp256k1.getById(BOUNCY_CASTLE)) {
-            SecpKeyPair keyPair = secp.ecKeyPairCreate(SecpPrivKey.of(key));
-            WitnessMaker maker = new WitnessMaker(secp);
-            byte[] witnessProgram = maker.calcWitnessProgram(keyPair.publicKey());
-            tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
-        }
+        SecpKeyPair keyPair = secp.ecKeyPairCreate(SecpPrivKey.of(key));
+        WitnessMaker maker = new WitnessMaker(secp);
+        byte[] witnessProgram = maker.calcWitnessProgram(keyPair.publicKey());
+        tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
         Assertions.assertEquals(address, tapRootAddress.toString());
     }
 
     @Test
-    void createAddressTestBouncyXO() throws Exception {
+    void createAddressTestXO() throws Exception {
         Address tapRootAddress;
-        try (Secp256k1 secp = Secp256k1.getById(BOUNCY_CASTLE)) {
-            WitnessMaker maker = new WitnessMaker(secp);
-            byte[] serial = HexFormat.of().parseHex("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
-            // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
-            // We need a Bouncy Castle Implementation first
-            SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(serial).get();
-            byte[] witnessProgram = maker.calcWitnessProgram(xOnlyKey);
-            tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
-        }
+        WitnessMaker maker = new WitnessMaker(secp);
+        byte[] serial = HexFormat.of().parseHex("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
+        // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
+        // We need a Bouncy Castle Implementation first
+        SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(serial).get();
+        byte[] witnessProgram = maker.calcWitnessProgram(xOnlyKey);
+        tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
         Assertions.assertEquals("bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5", tapRootAddress.toString());
     }
 
@@ -91,15 +92,13 @@ public class AddressTest {
     @Test
     void createAddressTest2() throws Exception {
         Address tapRootAddress;
-        try (Secp256k1 secp = Secp256k1.get()) {
-            WitnessMaker maker = new WitnessMaker(secp);
-            BigInteger internalPubKey = new BigInteger("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d", 16);
-            // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
-            // We need a Bouncy Castle Implementation first
-            SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(UInt256.integerTo32Bytes(internalPubKey)).get();
-            byte[] witnessProgram = maker.calcWitnessProgram(xOnlyKey);
-            tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
-        }
+        WitnessMaker maker = new WitnessMaker(secp);
+        BigInteger internalPubKey = new BigInteger("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d", 16);
+        // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
+        // We need a Bouncy Castle Implementation first
+        SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(UInt256.integerTo32Bytes(internalPubKey)).get();
+        byte[] witnessProgram = maker.calcWitnessProgram(xOnlyKey);
+        tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
         System.out.println(tapRootAddress);
     }
 }


### PR DESCRIPTION
Add Secp256k1. ecPubKeyFromXOnly() for xOnly to full pubkey conversion.
Use it in our experimental bitcoinj address generation/test module.
The next step for WitnessMaker/AddressTest is some real test vectors.

Cherry-picked:

* dd7630e5ef2cf007c3287bb953e60cd78823a6e5
* f4c47fc38cdb6a3983bbfd4e1b445296294b3444
* 2dcdd3959b25c89f366d4ae9bc606e116bea810e
