### PR TITLE
Implement and test `xOnlyPubKeyParse` for Bouncy Castle

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -27,6 +27,7 @@ import org.bitcoinj.secp.EcdsaSignature;
 import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.SecpKeyPairImpl;
 import org.bitcoinj.secp.internal.SecpScalarImpl;
+import org.bitcoinj.secp.internal.SecpXOnlyPubKeyImpl;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.digests.SHA256Digest;
@@ -43,6 +44,7 @@ import org.bouncycastle.math.ec.FixedPointCombMultiplier;
 import org.bouncycastle.math.ec.FixedPointUtil;
 
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -155,7 +157,22 @@ public class Bouncy256k1 implements Secp256k1 {
 
     @Override
     public SecpResult<SecpXOnlyPubKey> xOnlyPubKeyParse(byte[] inputData) {
-        throw new UnsupportedOperationException();
+        try {
+            // Bouncy Castle expects compressed format, not X-Only
+            byte[] serialized = prependByte(inputData, (byte) 0x2);
+            BC_CURVE.getCurve().decodePoint(serialized);
+        } catch (IllegalArgumentException e) {
+            // If `decodePoint` fails, pubkey is invalid
+            return SecpResult.err(0);
+        }
+        return SecpResult.ok(SecpXOnlyPubKeyImpl.ofVerifiedBytes(inputData));
+    }
+
+    private byte[] prependByte(byte[] inputArray, byte toPrepend) {
+        return ByteBuffer.allocate(inputArray.length + 1)
+                .put(toPrepend)
+                .put(inputArray)
+                .array();
     }
 
     @Override

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/PubKeyTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/PubKeyTest.java
@@ -28,13 +28,17 @@ import java.util.HexFormat;
 import static org.bitcoinj.secp.integration.SecpTestSupport.parseHex;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  */
 public class PubKeyTest implements SecpTestSupport {
     byte[] ONE_SERIALIZED = parseHex("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8");
+    byte[] GOOD_X_ONLY = parseHex("F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9");
+    byte[] BAD_X_ONLY = parseHex("EEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34");
 
     @MethodSource("secpImplementations")
     @ParameterizedTest(name = "Test Pubkeys for {0}")
@@ -52,5 +56,12 @@ public class PubKeyTest implements SecpTestSupport {
         SecpPoint.Uncompressed roundTripPoint = secp.ecPointUncompress(cPoint);
 
         assertEquals(uPoint, roundTripPoint);
+    }
+
+    @MethodSource("secpImplementations")
+    @ParameterizedTest(name = "Test X-Only parsing for {0}")
+    void testXOnlyParse(Secp256k1 secp) {
+        assertTrue(secp.xOnlyPubKeyParse(GOOD_X_ONLY).isOk());
+        assertFalse(secp.xOnlyPubKeyParse(BAD_X_ONLY).isOk());
     }
 }


### PR DESCRIPTION
Implements `xOnlyPubKeyParse` using Bouncy Castle's `decodePoint` to verify bytes. Also adds tests for both implementation's `xOnlyPubKeyParse` using a valid and invalid x-only public key.