### PR TITLE
Add exception handling for Bouncy Castle `ecPubKeyParse`

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -149,8 +149,13 @@ public class Bouncy256k1 implements Secp256k1 {
 
     @Override
     public SecpResult<SecpPubKey> ecPubKeyParse(byte[] inputData) {
-        ECPoint bcPoint = BC_CURVE.getCurve().decodePoint(inputData);
-        return SecpResult.ok(BC.toSecpPubKey(bcPoint));
+        try {
+            ECPoint bcPoint = BC_CURVE.getCurve().decodePoint(inputData);
+            return SecpResult.ok(BC.toSecpPubKey(bcPoint));
+        } catch (IllegalArgumentException e) {
+            return SecpResult.err(0);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Add a catch for the `IllegalArgumentException` thrown when an invalid public key is given and return a `SecpResult.Err` if so.