### PR TITLE
Remove unnecessary `BC_ECDOMAIN_PARAMS` references

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -168,7 +168,7 @@ public class Bouncy256k1 implements Secp256k1 {
         try {
             // Bouncy Castle expects compressed format, not X-Only
             byte[] serialized = prependByte(inputData, (byte) 0x2);
-            BC_ECDOMAIN_PARAMS.getCurve().decodePoint(serialized);
+            BC_CURVE.decodePoint(serialized);
         } catch (IllegalArgumentException e) {
             // If `decodePoint` fails, pubkey is invalid
             return SecpResult.err(0);

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -224,7 +224,7 @@ public class Bouncy256k1 implements Secp256k1 {
     BigInteger canonicalize(BigInteger s) {
         return s.compareTo(HALF_CURVE_ORDER) <= 0
                 ? s
-                : BC_ECDOMAIN_PARAMS.getN().subtract(s);
+                : Secp256k1.N.subtract(s);
     }
 
     @Override


### PR DESCRIPTION
Additional cleanup made possible, in part, by #375.