### PR TITLE
Add `schnorrSigSign32` with `auxiliaryRandom` as a parameter to the API

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -299,6 +299,15 @@ public interface Secp256k1 extends Closeable {
     SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpPrivKey privKey);
 
     /**
+     * Create a Schnorr signature for a message.
+     * @param messageHash a hash of a message to sign
+     * @param privKey private key for signing
+     * @param auxiliaryRandom auxiliary randomness (typically from a test vector)
+     * @return the signature
+     */
+    SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpPrivKey privKey, byte[] auxiliaryRandom);
+
+    /**
      * Verify a Schnorr signature.
      * @param signature the signature to verify
      * @param msg_hash hash of the message

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -285,6 +285,11 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
+    public SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpPrivKey privKey, byte[] auxiliaryRandom) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public SecpResult<Boolean> schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey) {
         return SecpResult.err(-1);
     }


### PR DESCRIPTION
In order to parameterize tests across implementations, an overload of `schnorrSigSign32` is needed which takes auxiliary random data from a byte array.