### PR TITLE
WitnessMaker, AddressTest: basic/correct BIP-341 implementation/tests

### DIFF
--- a/secp-bitcoinj/src/main/java/org/bitcoinj/secp/bitcoinj/WitnessMaker.java
+++ b/secp-bitcoinj/src/main/java/org/bitcoinj/secp/bitcoinj/WitnessMaker.java
@@ -15,67 +15,50 @@
  */
 package org.bitcoinj.secp.bitcoinj;
 
-import org.bitcoinj.secp.SecpPubKey;
+import org.bitcoinj.secp.SecpFieldElement;
+import org.bitcoinj.secp.SecpPoint;
+import org.bitcoinj.secp.SecpScalar;
 import org.bitcoinj.secp.SecpXOnlyPubKey;
 import org.bitcoinj.secp.Secp256k1;
-import org.bitcoinj.secp.internal.SecpPubKeyImpl;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
 
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * Experimental class for making P2TR witness programs
  */
 public class WitnessMaker {
-    /**
-     * 64-byte concatenation of two 32-byte hashes of "TapTweak"
-     */
-    private static final byte[] tweakPrefix = calcTagPrefix64("TapTweak");
+    static final byte[] TAG_TAP_TWEAK = "TapTweak".getBytes(StandardCharsets.UTF_8);
+
     private final Secp256k1 secp;
 
     public WitnessMaker(Secp256k1 secp) {
         this.secp = secp;
     }
 
-    public byte[] calcWitnessProgram(SecpPubKey pubKey) {
-        BigInteger tweakInt = calcTweak(pubKey.xOnly());
-        SecpPubKey G = new SecpPubKeyImpl(Secp256k1.G);
-        SecpPubKey P2 = secp.ecPubKeyTweakMul(G, tweakInt);
-        SecpPubKey Q = secp.ecPubKeyCombine(pubKey, P2);
-        return Q.xOnly().serialize();
+    /// P = secp.ecPubKeyFromXOnly(xOnlyPubKey)
+    /// The formula from BIP-341:
+    /// Q = P + int(hashTapTweak(bytes(P))) * G
+    /// returns Q.x()
+    /// @param xOnlyPubKey The x-only pubKey
+    /// @return tweaked, pubKey as an x-only field element
+    public SecpFieldElement tweakedPubKey(SecpXOnlyPubKey xOnlyPubKey) {
+        SecpScalar tweak = hashTapTweak(xOnlyPubKey);
+        return tweakedPubKey(xOnlyPubKey, tweak);
     }
 
-    public byte[] calcWitnessProgram(SecpXOnlyPubKey xOnlyPubKey) {
-        return calcWitnessProgram(secp.ecPubKeyFromXOnly(xOnlyPubKey));
+    /// Return Q.x(), where Q = P + tweak * G
+    SecpFieldElement tweakedPubKey(SecpXOnlyPubKey xOnlyPubKey, SecpScalar tweak) {
+        SecpPoint.Uncompressed P = secp.ecPubKeyFromXOnly(xOnlyPubKey);
+        SecpPoint.Uncompressed tempPoint = secp.ecPubKeyTweakMul(Secp256k1.G, tweak.toBigInteger()).point();
+        // tweakedPubKey (aka Q)
+        SecpPoint.Uncompressed Q = secp.ecPubKeyCombine(P, tempPoint);
+        return Q.x();
     }
 
-    public static BigInteger calcTweak(SecpXOnlyPubKey xOnlyPubKey) {
-        var digest = newDigest();
-        digest.update(tweakPrefix);
-        byte[] hash = digest.digest(xOnlyPubKey.serialize());
-        return new BigInteger(1, hash);
-    }
-
-    public static byte[] calcTagPrefix64(String tag) {
-        byte[] hash = hash256(tag.getBytes(StandardCharsets.UTF_8));
-        return ByteBuffer.allocate(64)
-                .put(hash)
-                .put(hash)
-                .array();
-    }
-
-    private static byte[] hash256(byte[] message) {
-        return newDigest().digest(message);
-    }
-
-    private static MessageDigest newDigest() {
-        try {
-            return MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);  // Can't happen.
-        }
+    /// int(hashTapTweak(bytes(P)))
+    SecpScalar hashTapTweak(SecpXOnlyPubKey xOnlyPubKey) {
+        byte[] tweak = secp.taggedSha256(TAG_TAP_TWEAK, xOnlyPubKey.serialize());
+        return new SecpScalarImpl(tweak);
     }
 }

--- a/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
+++ b/secp-bitcoinj/src/test/java/org/bitcoinj/secp/bitcoinj/AddressTest.java
@@ -19,8 +19,10 @@ import org.bitcoinj.base.Address;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.SegwitAddress;
+import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpKeyPair;
 import org.bitcoinj.secp.SecpPrivKey;
+import org.bitcoinj.secp.SecpScalar;
 import org.bitcoinj.secp.SecpXOnlyPubKey;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.internal.UInt256;
@@ -38,8 +40,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Work-in-progress experiments to create Taproot addresses from private keys.
- * Needs to be rewritten using known test vectors.
+ * Work-in-progress experiments to create Taproot addresses from keys.
  */
 @ParameterizedClass
 @MethodSource("secpImplementations")
@@ -66,39 +67,56 @@ public class AddressTest {
         Address tapRootAddress;
         SecpKeyPair keyPair = secp.ecKeyPairCreate(SecpPrivKey.of(key));
         WitnessMaker maker = new WitnessMaker(secp);
-        byte[] witnessProgram = maker.calcWitnessProgram(keyPair.publicKey());
-        tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
+        SecpFieldElement tweakedPubKey = maker.tweakedPubKey(keyPair.publicKey().xOnly());
+        tapRootAddress = SegwitAddress.fromProgram(network, 1, tweakedPubKey.serialize());
         Assertions.assertEquals(address, tapRootAddress.toString());
     }
 
+    /// Run the 0th BIP-341 test vector, without checking intermediate values
     @Test
-    void createAddressTestXO() throws Exception {
-        Address tapRootAddress;
+    void bipVector0() {
+        byte[] serializedInternalPubKey = parseHex("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
+        String expectedBip350Address = "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5";
+
         WitnessMaker maker = new WitnessMaker(secp);
-        byte[] serial = HexFormat.of().parseHex("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
-        // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
-        // We need a Bouncy Castle Implementation first
-        SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(serial).get();
-        byte[] witnessProgram = maker.calcWitnessProgram(xOnlyKey);
-        tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
-        Assertions.assertEquals("bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5", tapRootAddress.toString());
+        SecpXOnlyPubKey internalPubkey = secp.xOnlyPubKeyParse(serializedInternalPubKey).get();
+        SecpFieldElement tweakedPubKey = maker.tweakedPubKey(internalPubkey);
+        Address tapRootAddress = SegwitAddress.fromProgram(network, 1, tweakedPubKey.serialize());
+
+        Assertions.assertEquals(expectedBip350Address, tapRootAddress.toString());
     }
 
     private static final List<Arguments> keyAddressArgs = List.of(
             Arguments.of(BigInteger.ONE, "bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9"),
-            Arguments.of(BigInteger.TEN, "bc1pz6sunwdvdy6t4df4wynddj8wv7rttzl8m384h72ghnxlu2wcquks3sgk7p")
+            Arguments.of(BigInteger.TEN, "bc1p5mmme8n7pqk4x55sky33h3xxu0hp9tnuszt78szmhv8su25a4y3smy8tg3")
     );
 
+    /// Run the 0th BIP-341 test vector, checking intermediate values
+    /// Q = P + int(hashTapTweak(bytes(P)))G
     @Test
-    void createAddressTest2() throws Exception {
-        Address tapRootAddress;
+    void bipVector0WithIntermediateChecks() {
+        byte[] serializedInternalPubKey = parseHex("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
+        byte[] expectedTweak = parseHex("b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70");
+        byte[] expectedTweakedPubkey = parseHex("53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343");
+        String expectedBip350Address = "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5";
+
         WitnessMaker maker = new WitnessMaker(secp);
-        BigInteger internalPubKey = new BigInteger("d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d", 16);
-        // TODO: Use `secp.xOnlyPubKeyParse(serial)` here instead of `SecpXOnlyPubKey.parse(serial)`
-        // We need a Bouncy Castle Implementation first
-        SecpXOnlyPubKey xOnlyKey = SecpXOnlyPubKey.parse(UInt256.integerTo32Bytes(internalPubKey)).get();
-        byte[] witnessProgram = maker.calcWitnessProgram(xOnlyKey);
-        tapRootAddress = SegwitAddress.fromProgram(network, 1, witnessProgram);
-        System.out.println(tapRootAddress);
+        SecpXOnlyPubKey internalPubkey = secp.xOnlyPubKeyParse(serializedInternalPubKey).get();
+        // tweak = int(hashTapTweak(bytes(P))))
+        SecpScalar tweak = maker.hashTapTweak(internalPubkey);
+
+        Assertions.assertArrayEquals(expectedTweak, tweak.serialize());
+
+        // tweakedPubKey (aka Q.x(), where Q = P + int(hashTapTweak(bytes(P)))G)
+        SecpFieldElement tweakedPubKey = maker.tweakedPubKey(internalPubkey, tweak);
+
+        Assertions.assertArrayEquals(expectedTweakedPubkey, tweakedPubKey.serialize());
+
+        Address tapRootAddress = SegwitAddress.fromProgram(network, 1, tweakedPubKey.serialize());
+        Assertions.assertEquals(expectedBip350Address, tapRootAddress.toString());
+    }
+
+    byte[] parseHex(String hexString) {
+        return HexFormat.of().parseHex(hexString);
     }
 }


### PR DESCRIPTION
Both WitnessMaker and AddressTest were in a bad/WIP state.

`WitnessMaker`:

* Rewrite to more closely follow the BIP and to provide
  methods that support testing "intermediary" values from the test vector.
* Adds comments relating computations and variables back
  to the BIP.

`AddressTest`:

* Update createAddressTest() use new methods in WitnessMaker
* Fix incorrect address for private key of `BigInteger.TEN` in test vectors `keyAddressArgs`. The previous
  implementation was incorrectly using an odd-y value in a calculation which is fixed in the new implementation
  and which revealed the correct test vector. See closed PR #385 for a demonstration "fix" for the old code. 
* Replace createAddressTestXO() with bipVector0() which uses the new
  methods in WitnessMaker and matches JSON member names in the test vector.
* Add bipVector0WithIntermediateChecks() which calls package-private
  methods that compute intermediary values from the test vector and verifies
  correct implementation.
* Remove createAddressTest2() -- it was redundant
