### PR TITLE
Update `jextract` headers

### DIFF
--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_ecdsa_signature.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_ecdsa_signature.java
@@ -115,7 +115,7 @@ public class secp256k1_ecdsa_signature {
      * }
      */
     public static byte data(MemorySegment struct, long index0) {
-        return (byte)data$ELEM_HANDLE.get(struct, 0L, index0);
+        return (byte)data$ELEM_HANDLE.get(struct, data$OFFSET, index0);
     }
 
     /**
@@ -125,7 +125,7 @@ public class secp256k1_ecdsa_signature {
      * }
      */
     public static void data(MemorySegment struct, long index0, byte fieldValue) {
-        data$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+        data$ELEM_HANDLE.set(struct, data$OFFSET, index0, fieldValue);
     }
 
     /**

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_h.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_h.java
@@ -102,7 +102,7 @@ public class secp256k1_h extends secp256k1_h$shared {
     public static final OfLong size_t = secp256k1_h.C_LONG;
     /**
      * {@snippet lang=c :
-     * typedef unsigned int wchar_t
+     * typedef int wchar_t
      * }
      */
     public static final OfInt wchar_t = secp256k1_h.C_INT;

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_keypair.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_keypair.java
@@ -115,7 +115,7 @@ public class secp256k1_keypair {
      * }
      */
     public static byte data(MemorySegment struct, long index0) {
-        return (byte)data$ELEM_HANDLE.get(struct, 0L, index0);
+        return (byte)data$ELEM_HANDLE.get(struct, data$OFFSET, index0);
     }
 
     /**
@@ -125,7 +125,7 @@ public class secp256k1_keypair {
      * }
      */
     public static void data(MemorySegment struct, long index0, byte fieldValue) {
-        data$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+        data$ELEM_HANDLE.set(struct, data$OFFSET, index0, fieldValue);
     }
 
     /**

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_pubkey.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_pubkey.java
@@ -115,7 +115,7 @@ public class secp256k1_pubkey {
      * }
      */
     public static byte data(MemorySegment struct, long index0) {
-        return (byte)data$ELEM_HANDLE.get(struct, 0L, index0);
+        return (byte)data$ELEM_HANDLE.get(struct, data$OFFSET, index0);
     }
 
     /**
@@ -125,7 +125,7 @@ public class secp256k1_pubkey {
      * }
      */
     public static void data(MemorySegment struct, long index0, byte fieldValue) {
-        data$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+        data$ELEM_HANDLE.set(struct, data$OFFSET, index0, fieldValue);
     }
 
     /**

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_schnorrsig_extraparams.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_schnorrsig_extraparams.java
@@ -120,7 +120,7 @@ public class secp256k1_schnorrsig_extraparams {
      * }
      */
     public static byte magic(MemorySegment struct, long index0) {
-        return (byte)magic$ELEM_HANDLE.get(struct, 0L, index0);
+        return (byte)magic$ELEM_HANDLE.get(struct, magic$OFFSET, index0);
     }
 
     /**
@@ -130,7 +130,7 @@ public class secp256k1_schnorrsig_extraparams {
      * }
      */
     public static void magic(MemorySegment struct, long index0, byte fieldValue) {
-        magic$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+        magic$ELEM_HANDLE.set(struct, magic$OFFSET, index0, fieldValue);
     }
 
     /**

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_xonly_pubkey.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract/secp256k1_xonly_pubkey.java
@@ -115,7 +115,7 @@ public class secp256k1_xonly_pubkey {
      * }
      */
     public static byte data(MemorySegment struct, long index0) {
-        return (byte)data$ELEM_HANDLE.get(struct, 0L, index0);
+        return (byte)data$ELEM_HANDLE.get(struct, data$OFFSET, index0);
     }
 
     /**
@@ -125,7 +125,7 @@ public class secp256k1_xonly_pubkey {
      * }
      */
     public static void data(MemorySegment struct, long index0, byte fieldValue) {
-        data$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+        data$ELEM_HANDLE.set(struct, data$OFFSET, index0, fieldValue);
     }
 
     /**


### PR DESCRIPTION
Headers are now those produced by `jextract 25-jextract+2-4`. This will be available in `nixpkgs` as `0-unstable-2025-11-12`.

```
rev = "91fc954c46fac907cae6cd1417d835208c9df150";
hash = "sha256-RAK7A0BCFaYe/q1nCdvXk091bhSj9DKxg2uQfABk4eo=";
```