### PR TITLE
flake.nix: remove x86_64-darwin from the `systems` list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
   outputs = inputs @ { nixpkgs, nixpkgs-unstable, ... }:
     let
-      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
       forEachSystem = f: builtins.listToAttrs (map (system: {
         name = system;
         value = f system;


### PR DESCRIPTION
`graalvm-ce` has dropped support for x86_64 Darwin and we use it in our build. Apple will be dropping support for it in macOS 27 (expected June 2026), Nixpkgs will be dropping it in release 26.11.