### PR TITLE
Secp256k1Foreign: fix endianness in ecdsaSignatureParseCompact()

### DIFF
--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -364,9 +364,11 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
 
     @Override
     public SecpResult<EcdsaSignature> ecdsaSignatureParseCompact(byte[] serialized_signature) {
+        // Use secp256k1_ecdsa_signature_parse_compact to validate the bytes,
+        // but pass serialized signature (in big-endian format) to the EcdsaSignatureImpl constructor.
         MemorySegment sig = secp256k1_ecdsa_signature.allocate(arena);
         int return_val = secp256k1_h.secp256k1_ecdsa_signature_parse_compact(ctx, sig, arena.allocateFrom(JAVA_BYTE, serialized_signature));
-        return SecpResult.checked(return_val, () -> EcdsaSignature.of(sig.toArray(JAVA_BYTE)));
+        return SecpResult.checked(return_val, () -> EcdsaSignature.of(serialized_signature));
     }
 
     @Override

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.bitcoinj.secp.integration.SecpTestSupport.hash;
+import static org.bitcoinj.secp.integration.SecpTestSupport.parseHex;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -101,5 +102,13 @@ public class EcdsaTest implements SecpTestSupport {
             assertTrue(secp2.ecdsaVerify(sig1, msg_hash, pubKey1).get());
             assertTrue(secp2.ecdsaVerify(sig2, msg_hash, pubKey2).get());
         }
+    }
+
+    @MethodSource("secpImplementations")
+    @ParameterizedTest(name = "Test parseCompact for {0}")
+    void testParseCompact(Secp256k1 secp) {
+        byte[] sigBytes = parseHex("252EC55A0CB7CD96F3BA47D7B3E16876C75F00CCF85B5F0CA5C51A8058BA9E7640F5D8DF25ADED2A4EA8DD7B2CA4CD3D8A3187D6FEF24A9C7111B9F9B4E0CFAE");
+        EcdsaSignature signature = secp.ecdsaSignatureParseCompact(sigBytes).get();
+        assertArrayEquals(sigBytes, signature.serializeCompact());
     }
 }


### PR DESCRIPTION
secp256k1_h.secp256k1_ecdsa_signature_parse_compact() parses and converts to libsecp _internal_ format, but EcdsaSignatureImpl stores the bytes in serialized/big-endian format.

This fix, uses secp256k1_ecdsa_signature_parse_compact for validation, but stores the serialized/big-endian bytes in EcdsaSignatureImpl.

A simple unit test is added. (More should be added later.)