### PR TITLE
flake.nix: upgrade nixpkgs to release-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778763724,
-        "narHash": "sha256-062g+AL65fpj55up6vIIuuWlZFgk6eVbe7VL5ni9qv0=",
+        "lastModified": 1779842643,
+        "narHash": "sha256-Jwzcu6c3FGkVVx9KPsu97AwCsFC747GFH15W16+h4k8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fbc1b6e6d1adc4481d8574c94ee25d4280732f31",
+        "rev": "6e6a50bcb10176ba222aa5b89005dce1b77863fb",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "secp2565k1-jdk (Java API & implementations for secp256k1)";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/release-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/release-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
@@ -26,7 +26,7 @@
         jdk = pkgs.jdk25;
         graalvm = pkgs.graalvmPackages.graalvm-ce;
         sharedShellHook = ''
-            export LIBSECP_DIR="${pkgs-unstable.lib.makeLibraryPath [ pkgs-unstable.secp256k1 ]}"
+            export LIBSECP_DIR="${pkgs.lib.makeLibraryPath [ pkgs.secp256k1 ]}"
             if [[ "$(uname)" == "Darwin" ]]; then
               export DYLD_LIBRARY_PATH="$LIBSECP_DIR:$DYLD_LIBRARY_PATH"
             else
@@ -39,7 +39,7 @@
         in {
         # define default devshell, with a richer collection of tools intended for interactive development
         default = pkgs.mkShell {
-          buildInputs = with pkgs-unstable ; [ secp256k1 zlib ];
+          buildInputs = with pkgs ; [ secp256k1 zlib ];
           packages = with pkgs ; [
                 jdk                        # This JDK will be in PATH
                 # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
@@ -55,7 +55,7 @@
         };
         # define minimum devshell, with the minimum necessary to do a CI build
         minimum = pkgs.mkShell {
-          buildInputs = with pkgs-unstable ; [ secp256k1 zlib ];
+          buildInputs = with pkgs ; [ secp256k1 zlib ];
           packages = with pkgs ; [
                 graalvm                    # This JDK will be in PATH
                 (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK


### PR DESCRIPTION
This updates the following:

graalvm-ce  25.0.2 (from 25.0.0)
gradle_9    9.4.1 (from 9.3.1)
secp256k1   0.7.1 (from 0.6.0, allowing us to cease use of nixpkgs-unstable)