### PR TITLE
secp-bitcoinj: make bouncy and ffm modules implementation dependencies

### DIFF
--- a/secp-bitcoinj/build.gradle
+++ b/secp-bitcoinj/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     api project(':secp-api')
     api("org.bitcoinj:bitcoinj-core:0.17.1");
 
-    runtimeOnly project(':secp-bouncy')
-    runtimeOnly project(':secp-ffm')
+    implementation project(':secp-bouncy')
+    implementation project(':secp-ffm')
 }
 
 jar {

--- a/secp-bitcoinj/src/main/java/module-info.java
+++ b/secp-bitcoinj/src/main/java/module-info.java
@@ -22,4 +22,8 @@ module org.bitcoinj.secp.bitcoinj {
     requires org.jspecify;
     requires org.bitcoinj.core;
     requires org.bouncycastle.provider;
+
+    // Explicitly declare these so they're put on the module-path for tests
+    requires org.bitcoinj.secp.bouncy;
+    requires org.bitcoinj.secp.ffm;
 }


### PR DESCRIPTION
Since this is an experimental module with a focus on testing and both these modules are used in the tests, let's make them implementation dependencies.

This will make porting to Maven (which wants to use the module path by default for tests in secp-bitcoinj) easier.