### PR TITLE
flake.nix: remove unused nixpkgs-unstable input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/release-26.05";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = inputs @ { nixpkgs, nixpkgs-unstable, ... }:
+  outputs = inputs @ { nixpkgs, ... }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
       forEachSystem = f: builtins.listToAttrs (map (system: {
@@ -18,9 +17,6 @@
         let
         inherit (pkgs) stdenv;
         pkgs = import nixpkgs {
-          inherit system;
-        };
-        pkgs-unstable = import nixpkgs-unstable {
           inherit system;
         };
         jdk = pkgs.jdk25;


### PR DESCRIPTION
When we upgraded to `nixpkgs-26.05`, we no longer needed to use the `nixpkgs-unstable` input, so all actual use of `nixpgs-unstable` was removed. But I left some setup code so that it would be easy (and a  minimal diff) if we need to start using `nixpkgs-unstable` to get access to a newer `libsecp256k1` (for example)

But the unused nixpkgs-unstable still gets configured in `flake.nix`, requires some parsing, and generates Dependabot updates.

So I think it's better to just remove the reference and we can add it back when needed.

After this is merged:

* PR #413 can be rebased.
* PR #412 can be rebased (which will trigger a close.)