### PR TITLE
flake.nix: set nixpkgs to nixos-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780058396,
-        "narHash": "sha256-tOmX9WrZO0ZMuwCuCmUPZZbrBgHf/Roll6R6d+k5074=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "282bc8530ef716e83e71090c7750c398108810f4",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-26.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "secp2565k1-jdk (Java API & implementations for secp256k1)";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/release-26.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
   };
 
   outputs = inputs @ { nixpkgs, ... }:


### PR DESCRIPTION
nixos-26.05 is the correct "stable" branch to use for release 26.05, having received the most testing and having the most extensive binary cache.

See: https://nix.dev/concepts/faq.html#stable