### PR TITLE
flake.nix: re-add jextract to default devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,8 +38,7 @@
           buildInputs = with pkgs ; [ secp256k1 zlib ];
           packages = with pkgs ; [
                 jdk                        # This JDK will be in PATH
-                # current jextract in nixpkgs is broken, see: https://github.com/NixOS/nixpkgs/issues/354591
-                # jextract                 # jextract (Nix package) contains a jlinked executable and bundles its own JDK
+                jextract                   # jextract (Nix package) contains a jlinked executable and bundles its own JDK
                 # Add `jreleaser` for pushing releases to GitLab/Maven Central or for doing "dry run" release testing.
                 (jreleaser-cli.override {
                      jre = jdk;            # Use the same JDK as we are using elsewhere


### PR DESCRIPTION
Now that these two PRs are in Nixpkgs 26.05, `jextract` should be up-to-date and working:

* https://github.com/NixOS/nixpkgs/pull/526581
* https://github.com/NixOS/nixpkgs/pull/526587