### PR TITLE
GHA build.yml: Fix CI_REVISION using `sed`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Compute CI revision
         run: |
           REVISION=$(mvn -q help:evaluate -Dexpression=revision -DforceStdout)
-          CI_REVISION="${REVISION%-SNAPSHOT}-ci"
+          CI_REVISION=$(echo "$REVISION" | sed 's/-SNAPSHOT$/-ci/')
           echo "CI_REVISION=$CI_REVISION" >> "$GITHUB_ENV"
       - name: Maven Deploy
         run: mvn -Drevision="$CI_REVISION" deploy
@@ -140,7 +140,7 @@ jobs:
         shell: 'nix develop -c bash -e {0}'    # Use the Pre-built devShell
         run: |
           REVISION=$(mvn -q help:evaluate -Dexpression=revision -DforceStdout)
-          CI_REVISION="${REVISION%-SNAPSHOT}-ci"
+          CI_REVISION=$(echo "$REVISION" | sed 's/-SNAPSHOT$/-ci/')
           echo "CI_REVISION=$CI_REVISION" >> "$GITHUB_ENV"
       - name: Maven Deploy
         shell: 'nix develop -c bash -e {0}'    # Use the Pre-built devShell


### PR DESCRIPTION
The previous version removes `-SNAPSHOT` if present and then unconditionally  adds `-ci` (e.g. `0.3` gets mapped to `0.3-ci`)

The fix is to use `sed` to do the swap.