### PR TITLE
Set output directory for Flatten Maven to `target`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,10 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
                     <version>${flatten-maven-plugin.version}</version>
+                    <configuration>
+                        <flattenedPomFilename>flattened-pom.xml</flattenedPomFilename>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Before this change, the generated flattened poms are outputted into the
same directory as the unflattened poms as hidden file. This change outputs
them to their respective `target` directory so that it isn't tracked by git
and makes it not hidden (by removing the leading ".").