### PR TITLE
Secp256k1Foreign, Secp256k1Bouncy: validate ECDSA message hashes as 32-byte

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -229,7 +229,7 @@ public interface Secp256k1 extends Closeable {
 
     /**
      * Sign a message hash using the ECDSA algorithm
-     * @param msg_hash_data hash of message to sign
+     * @param msg_hash_data 32-byte hash of message to sign
      * @param privKey private key
      * @return the signature
      */
@@ -239,7 +239,7 @@ public interface Secp256k1 extends Closeable {
      * Sign a message hash using the ECDSA algorithm and Low-R signature griding
      * <p>
      * This uses the same nonce-incrementing algorithm as Bitcoin Core to ensure a low-R signature.
-     * @param messageHashData hash of message to sign
+     * @param messageHashData 32-byte hash of message to sign
      * @param privKey private key
      * @return the signature
      */
@@ -266,7 +266,7 @@ public interface Secp256k1 extends Closeable {
     /**
      * Verify an ECDSA signature.
      * @param sig The signature to verify.
-     * @param msg_hash_data A hash of the message to verify.
+     * @param msg_hash_data A 32-byte hash of the message to verify.
      * @param pubKey The pubkey that must have signed the message
      * @return true, false, or error
      */

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -202,6 +202,7 @@ public class Bouncy256k1 implements Secp256k1 {
 
     @Override
     public SecpResult<EcdsaSignature> ecdsaSign(byte[] msg_hash_data, SecpPrivKey privKey) {
+        checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
         ECDSASigner signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
         ECPrivateKeyParameters bouncyPrivKey = new ECPrivateKeyParameters(privKey.getS(), BC_ECDOMAIN_PARAMS);
         signer.init(true, bouncyPrivKey);
@@ -211,6 +212,7 @@ public class Bouncy256k1 implements Secp256k1 {
 
     @Override
     public SecpResult<EcdsaSignature> ecdsaSignLowR(byte[] messageHashData, SecpPrivKey privKey) {
+        checkArg(messageHashData.length == 32, "Message must be 32-byte (hash)");
         HMacDSAKCalculatorWithEntropy kCalculator = new HMacDSAKCalculatorWithEntropy(new SHA256Digest());
         ECDSASigner signer = new ECDSASigner(kCalculator);
         ECPrivateKeyParameters bouncyPrivKey = new ECPrivateKeyParameters(privKey.getS(), BC_ECDOMAIN_PARAMS);
@@ -260,6 +262,7 @@ public class Bouncy256k1 implements Secp256k1 {
 
     @Override
     public SecpResult<Boolean> ecdsaVerify(EcdsaSignature signature, byte[] msg_hash_data, SecpPubKey pubKey) {
+        checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
         ECDSASigner signer = new ECDSASigner();
         ECPoint pubPoint = BC.fromSecpPoint(pubKey.point());
         ECPublicKeyParameters params = new ECPublicKeyParameters(pubPoint, BC_ECDOMAIN_PARAMS);

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -310,6 +310,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
 
     @Override
     public SecpResult<EcdsaSignature> ecdsaSign(byte[] msg_hash_data, SecpPrivKey privKey) {
+        checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
         /* Generate an ECDSA signature `noncefp` and `ndata` allows you to pass a
          * custom nonce function, passing `NULL` will use the RFC-6979 safe default.
          * Signing with a valid context, verified secret key
@@ -332,6 +333,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
      */
     @Override
     public SecpResult<EcdsaSignature> ecdsaSignLowR(byte[] msg_hash_data, SecpPrivKey privKey) {
+        checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
         MemorySegment msg_hash = arena.allocateFrom(JAVA_BYTE, msg_hash_data);
         MemorySegment privKeySeg = arena.allocateFrom(JAVA_BYTE, privKey.getEncoded());
         MemorySegment sig = secp256k1_ecdsa_signature.allocate(arena);  // internal signature format
@@ -374,6 +376,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
 
     @Override
     public SecpResult<Boolean> ecdsaVerify(EcdsaSignature sig, byte[] msg_hash_data, SecpPubKey pubKey) {
+        checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
         /* Generate an ECDSA signature `noncefp` and `ndata` allows you to pass a
          * custom nonce function, passing `NULL` will use the RFC-6979 safe default.
          * Signing with a valid context, verified secret key


### PR DESCRIPTION
Also add "32-byte" to the Javadoc in Secp256k1.java