### PR TITLE
SecpKeyPairImpl: implement isDestroyed()

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpKeyPairImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpKeyPairImpl.java
@@ -54,6 +54,11 @@ public class SecpKeyPairImpl implements SecpKeyPair {
     }
 
     @Override
+    public boolean isDestroyed() {
+        return privKey.isDestroyed();
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "{" + " publicKey = " + publicKey() + " }";
     }


### PR DESCRIPTION
Since destroy() is passed to the privKey member, isDestroyed() should query that member rather than the incorrect default behavior of returning `false`.