### PR TITLE
secp-ffm module-info.java: drop export of o.b.s.ffm.jextract

### DIFF
--- a/secp-ffm/src/main/java/module-info.java
+++ b/secp-ffm/src/main/java/module-info.java
@@ -24,7 +24,6 @@ module org.bitcoinj.secp.ffm {
     requires org.jspecify;
 
     exports org.bitcoinj.secp.ffm;
-    exports org.bitcoinj.secp.ffm.jextract;
 
     provides Secp256k1.Provider with org.bitcoinj.secp.ffm.ForeignProvider;
 }


### PR DESCRIPTION
The jextract headers should be for internal use only.