### PR TITLE
Deprecate some public unvalidated constructors

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/SchnorrSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SchnorrSignature.java
@@ -45,7 +45,8 @@ public interface SchnorrSignature {
      * @param bytes bytes
      * @return signature
      */
+    @Deprecated(forRemoval = true)
     static SchnorrSignature of(byte[] bytes) {
-        return new SchnorrSignatureImpl(bytes);
+        return SchnorrSignatureImpl.of(bytes);
     }
 }

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpKeyPair.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpKeyPair.java
@@ -39,6 +39,7 @@ public interface SecpKeyPair extends SecpPrivKey {
      * @param pubKey matching public key
      * @return key pair
      */
+    @Deprecated(forRemoval = true)
     static SecpKeyPair of(SecpPrivKey privKey, SecpPubKey pubKey) {
         return new SecpKeyPairImpl(privKey, pubKey);
     }

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
@@ -41,6 +41,7 @@ public interface SecpPoint {
      * @param y y component
      * @return point
      */
+    @Deprecated(forRemoval = true)
     static SecpPointUncompressed of(SecpFieldElement x, SecpFieldElement y) {
         return new SecpPointUncompressed(x, y);
     }
@@ -50,6 +51,7 @@ public interface SecpPoint {
      * @param point Java point
      * @return SecpPoint point
      */
+    @Deprecated(forRemoval = true)
     static SecpPoint of(ECPoint point) {
         return  point == ECPoint.POINT_INFINITY
                     ? SecpPoint.POINT_INFINITY

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SchnorrSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SchnorrSignatureImpl.java
@@ -36,6 +36,15 @@ public class SchnorrSignatureImpl implements SchnorrSignature, ByteArray {
         this.s = new SecpScalarImpl(Arrays.copyOfRange(signature, 32, 64));
     }
 
+    /**
+     * Create an ECDSA signature from serialized bytes
+     * @param bytes bytes
+     * @return signature
+     */
+    public static SchnorrSignature of(byte[] bytes) {
+        return new SchnorrSignatureImpl(bytes);
+    }
+
     @Override
     public SecpFieldElement r() {
         return r;

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/BIP340TestVectorTests.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/BIP340TestVectorTests.java
@@ -17,7 +17,6 @@ package org.bitcoinj.secp.integration;
 
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.exceptions.CsvException;
-import org.bitcoinj.secp.SchnorrSignature;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.SecpPrivKey;
 import org.bitcoinj.secp.SecpResult;
@@ -27,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.bitcoinj.secp.internal.SchnorrSignatureImpl;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
@@ -91,7 +91,7 @@ public class BIP340TestVectorTests implements SecpTestSupport {
     @FieldSource("SIGNVERIFY_VECTORS")
     void schnorrSigVerify(TestVector vec) {
         var pubKey = secp.xOnlyPubKeyParse(vec.pubKey).get();
-        var signature = SchnorrSignature.of(vec.signature);
+        var signature = SchnorrSignatureImpl.of(vec.signature);
 
         boolean actualResult = secp.schnorrSigVerify(signature, vec.message, pubKey).get();
 
@@ -131,7 +131,7 @@ public class BIP340TestVectorTests implements SecpTestSupport {
     @ParameterizedTest
     @FieldSource("INVALIDSIGNATURE_VECTORS")
     void schnorrSigFromInvalidBytes(TestVector vec) {
-        assertThrows(IllegalArgumentException.class, () -> SchnorrSignature.of(vec.signature));
+        assertThrows(IllegalArgumentException.class, () -> SchnorrSignatureImpl.of(vec.signature));
     }
 
     static final List<TestVector> SIGN32_VECTORS = ALL_VECTORS.stream()


### PR DESCRIPTION
The deprecated constructors in SecpKeyPair and SecpPoint are unused.

The deprecated SchnorrSignature.of() was used in a test, which is updated to use SchnorrSignatureImpl.of().