### PR TITLE
WIP: secp-integration-test on module path

### DIFF
--- a/secp-bouncy/src/main/java/module-info.java
+++ b/secp-bouncy/src/main/java/module-info.java
@@ -24,5 +24,7 @@ module org.bitcoinj.secp.bouncy {
     requires org.bouncycastle.provider;
     requires org.jspecify;
 
+    exports org.bitcoinj.secp.bouncy;
+
     provides Secp256k1.Provider with org.bitcoinj.secp.bouncy.BouncyProvider;
 }

--- a/secp-integration-test/src/main/java/module-info.java
+++ b/secp-integration-test/src/main/java/module-info.java
@@ -15,21 +15,12 @@
  */
 import org.bitcoinj.secp.Secp256k1;
 
-/**
- * API definition module for <a href="https://github.com/bitcoinj/secp256k1-jdk">secp256k1-jdk</a>, a Java library providing
- * <i>Elliptic Curve Cryptography</i> functions using the <a href="https://www.secg.org">SECG</a> curve
- * <a href="https://en.bitcoin.it/wiki/Secp256k1">secp256k1</a>.
- * It provides both ECDSA and Schnorr message signing and verification functions.
- * <p>
- * For more information see the package {@link org.bitcoinj.secp} or the main interface
- * {@link Secp256k1}.
- */
+/// Integration test module
 @org.jspecify.annotations.NullMarked
-module org.bitcoinj.secp {
+module org.bitcoinj.secp.integrationtest {
+    requires org.bitcoinj.secp;
     requires org.jspecify;
 
-    exports org.bitcoinj.secp;
-    exports org.bitcoinj.secp.internal to org.bitcoinj.secp.bouncy, org.bitcoinj.secp.ffm, org.bitcoinj.secp.bitcoinj, org.bitcoinj.secp.integrationtest.test;
 
     uses Secp256k1.Provider;
 }

--- a/secp-integration-test/src/test/java/module-info.java
+++ b/secp-integration-test/src/test/java/module-info.java
@@ -15,21 +15,22 @@
  */
 import org.bitcoinj.secp.Secp256k1;
 
-/**
- * API definition module for <a href="https://github.com/bitcoinj/secp256k1-jdk">secp256k1-jdk</a>, a Java library providing
- * <i>Elliptic Curve Cryptography</i> functions using the <a href="https://www.secg.org">SECG</a> curve
- * <a href="https://en.bitcoin.it/wiki/Secp256k1">secp256k1</a>.
- * It provides both ECDSA and Schnorr message signing and verification functions.
- * <p>
- * For more information see the package {@link org.bitcoinj.secp} or the main interface
- * {@link Secp256k1}.
- */
+/// Integration test module
 @org.jspecify.annotations.NullMarked
-module org.bitcoinj.secp {
+module org.bitcoinj.secp.integrationtest.test {
+    requires org.bitcoinj.secp;
+    requires org.bitcoinj.secp.bouncy;
+    requires org.bitcoinj.secp.ffm;
     requires org.jspecify;
+    requires org.junit.jupiter.api;
+    requires com.opencsv;
+    requires org.junit.jupiter.params;
 
-    exports org.bitcoinj.secp;
-    exports org.bitcoinj.secp.internal to org.bitcoinj.secp.bouncy, org.bitcoinj.secp.ffm, org.bitcoinj.secp.bitcoinj, org.bitcoinj.secp.integrationtest.test;
+    exports org.bitcoinj.secp.integration;
+    opens org.bitcoinj.secp.integration;
+
+    exports org.bitcoinj.secp.integration.internal;
+    opens org.bitcoinj.secp.integration.internal;
 
     uses Secp256k1.Provider;
 }


### PR DESCRIPTION
This seems to "work", but needs more careful review. And maybe we want to also have tests that don't run on the module path?