### PR TITLE
dependabot.yml: use "maven" package-ecosystem (switch from "gradle")

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
-# secp256k1-jdk Dependabot updates for Gradle and Nix
+# secp256k1-jdk Dependabot updates for Maven and Nix
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "gradle"
+  - package-ecosystem: "maven"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
We neglected to update `dependabot.yml` when we switched from Gradle to Maven. We missed the Bouncy Castle 1.85 update (partly) because of this.