### PR TITLE
Secp256k1Foreign: optimization for signLowR

### DIFF
--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -325,18 +325,22 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         MemorySegment privKeySeg = arena.allocateFrom(JAVA_BYTE, privKey.getEncoded());
         MemorySegment sig = secp256k1_ecdsa_signature.allocate(arena);  // internal signature format
         MemorySegment serSigSeg = secp256k1_ecdsa_signature.allocate(arena);  // serialized signature format
-        LowRGrindingNonce nonce = LowRGrindingNonce.zero(arena);
+        MemorySegment nonce = null;
         int count = 0;
         int return_val;
         do {
             // Sign the message, producing a signature in `sig`
-            if (count++ == 0) {
+            if (count == 0) {
                 return_val = secp256k1_h.secp256k1_ecdsa_sign(ctx, sig, msg_hash, privKeySeg, NULL, NULL);
             } else {
-                return_val = secp256k1_h.secp256k1_ecdsa_sign(ctx, sig, msg_hash, privKeySeg, NULL, nonce.segment());
+                if (nonce == null) {
+                    nonce = LowRGrindingNonce.allocate(arena);
+                }
+                LowRGrindingNonce.setCounter(nonce, count);
+                return_val = secp256k1_h.secp256k1_ecdsa_sign(ctx, sig, msg_hash, privKeySeg, NULL, nonce);
             }
+            count++;
             secp256k1_h.secp256k1_ecdsa_signature_serialize_compact(ctx, serSigSeg, sig);
-            nonce.increment();                      // Increment the counter field in the nonce
         } while (return_val == OK && !hasLowR(serSigSeg)); // Retry until we get an error or low-R
         privKeySeg.fill((byte) 0x00);
         return SecpResult.checked(return_val, () -> new EcdsaSignatureImpl(serSigSeg.toArray(JAVA_BYTE)));

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -342,9 +342,12 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return SecpResult.checked(return_val, () -> new EcdsaSignatureImpl(serSigSeg.toArray(JAVA_BYTE)));
     }
 
-    private static boolean hasLowR(MemorySegment serSigSeg) {
-        byte highByte = serSigSeg.toArray(JAVA_BYTE)[0];
-        return highByte >= 0;
+    /// Check whether a signature has a low-R value. Since the serialized format is big-endian,
+    /// we simply get the first {@code byte} and check its sign.
+    /// @param serializedSignatureSegment a serialized, compact low-R signature in a memory segment
+    /// @return true if a valid, low-R signature
+    private static boolean hasLowR(MemorySegment serializedSignatureSegment) {
+        return serializedSignatureSegment.get(JAVA_BYTE, 0) >= 0;
     }
 
     @Override

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonce.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonce.java
@@ -22,38 +22,28 @@ import java.lang.foreign.StructLayout;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
 
-/**
- * Memory layout for working with Low-R grinding nonces. A 32-byte segment with a 4-byte, little-endian
- * counter at offset zero.
- */
-public class LowRGrindingNonce {
-    static final ValueLayout.OfInt COUNT_LAYOUT = ValueLayout.JAVA_INT.withOrder(ByteOrder.LITTLE_ENDIAN);
-    static final StructLayout LAYOUT = MemoryLayout.structLayout(
+/// Memory layout for working with Low-R grinding nonces. A 32-byte segment with a 4-byte, little-endian
+/// counter at offset zero.
+public interface LowRGrindingNonce {
+    ValueLayout.OfInt COUNT_LAYOUT = ValueLayout.JAVA_INT.withOrder(ByteOrder.LITTLE_ENDIAN);
+    StructLayout LAYOUT = MemoryLayout.structLayout(
             COUNT_LAYOUT.withName("counter"),     // 4 bytes
             MemoryLayout.sequenceLayout(28, ValueLayout.JAVA_BYTE).withName("remaining")   // 28 bytes
     );
 
-    private final MemorySegment segment;
-    private int counter;
-
-    private LowRGrindingNonce(MemorySegment segment) {
-        this.segment = segment;
-        this.counter = 0;
+    /// Allocate a low-R grinding nonce. Note that {@link Arena#allocate(MemoryLayout)} will initialize the
+    /// segment to zeros, so in {@link LowRGrindingNonce#setCounter(MemorySegment, int)} we only need to write the counter.
+    /// @param arena arena to allocate from
+    /// @return a memory segment containing the nonce
+    static MemorySegment allocate(Arena arena) {
+        return arena.allocate(LAYOUT);
     }
 
-    public static LowRGrindingNonce zero(Arena arena) {
-        return new LowRGrindingNonce(arena.allocate(LAYOUT.byteSize()));
-    }
-
-    public void increment() {
-        segment.set(COUNT_LAYOUT, 0, ++counter);
-    }
-
-    public MemorySegment segment() {
-        return segment;
-    }
-
-    public byte[] bytes() {
-        return segment.toArray(ValueLayout.JAVA_BYTE);
+    /// Set the counter area of the low-R grinding nonce with the given counter value. This assumes the rest
+    /// of the segment is filled with zero bytes.
+    /// @param nonce The nonce to set
+    /// @param counter The iteration counter
+    static void setCounter(MemorySegment nonce, int counter) {
+        nonce.set(COUNT_LAYOUT, 0, counter);
     }
 }

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonce.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonce.java
@@ -32,7 +32,6 @@ public class LowRGrindingNonce {
             COUNT_LAYOUT.withName("counter"),     // 4 bytes
             MemoryLayout.sequenceLayout(28, ValueLayout.JAVA_BYTE).withName("remaining")   // 28 bytes
     );
-    static private final long COUNT_OFFSET = LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("counter"));
 
     private final MemorySegment segment;
     private int counter;
@@ -47,7 +46,7 @@ public class LowRGrindingNonce {
     }
 
     public void increment() {
-        segment.set(COUNT_LAYOUT, COUNT_OFFSET, ++counter);
+        segment.set(COUNT_LAYOUT, 0, ++counter);
     }
 
     public MemorySegment segment() {

--- a/secp-ffm/src/test/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonceTest.java
+++ b/secp-ffm/src/test/java/org/bitcoinj/secp/ffm/segments/LowRGrindingNonceTest.java
@@ -18,6 +18,8 @@ package org.bitcoinj.secp.ffm.segments;
 import org.junit.jupiter.api.Test;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.util.HexFormat;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -26,16 +28,19 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  * Basic test of {@link LowRGrindingNonce}
  */
 public class LowRGrindingNonceTest {
-    static final byte[] nonce0 = new byte[32];
-    static final byte[] nonce1 = HexFormat.of().parseHex("01" + "00".repeat(31));
+    static final byte[] exp_nonce0 = new byte[32];
+    static final byte[] exp_nonce1 = HexFormat.of().parseHex("01" + "00".repeat(31));
 
     @Test
     void basicTest() {
         try (var arena = Arena.ofShared()) {
-            var nonce = LowRGrindingNonce.zero(arena);
-            assertArrayEquals(nonce0, nonce.bytes(), "");
-            nonce.increment();
-            assertArrayEquals(nonce1, nonce.bytes(), "");
+            MemorySegment nonce = LowRGrindingNonce.allocate(arena);
+            LowRGrindingNonce.setCounter(nonce, 0);
+            byte[] nonce0 = nonce.toArray(ValueLayout.JAVA_BYTE);
+            assertArrayEquals(exp_nonce0, nonce0, "");
+            LowRGrindingNonce.setCounter(nonce, 1);
+            byte[] nonce1 = nonce.toArray(ValueLayout.JAVA_BYTE);
+            assertArrayEquals(exp_nonce1, nonce1, "");
         }
     }
 }


### PR DESCRIPTION
A sequence of commit that clean up and optimize the FFM implementation of Low-R Grinding. See comments on individual commits for details.

1. hasLowR() read high-byte directly from MemorySegment, rather than copy to array first
2. Replace `COUNT_OFFSET` with `0` (the verbosity isn't needed)
3. `LowRGrindingNonce`  convert to an interface that returns a `MemorySegment` and restructure the grind loop so that we're allocating the segment zero or one times and are not allocating a Java wrapper for it. This also eliminates keeping a separate counter in the `LowRGrindingNonce` instance.


