### PR TITLE
Secp256k1Foreign: remove static `globalArena`

### DIFF
--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -252,7 +252,11 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return pubKey.serialize(compressed);
     }
 
-    /* package */ static MemorySegment pubKeySerializeSegment(MemorySegment pubKeySegment, int flags) {
+    /// Create a serialized pubKey from an internal format pubKey
+    /// @param pubKeySegment pubKey in internal format
+    /// @param flags flags for serialization
+    /// @return serialized pubKey
+    static MemorySegment pubKeySerializeSegment(MemorySegment pubKeySegment, int flags) {
         int byteSize = switch(flags) {
             case 2 -> 65;           // SECP256K1_EC_UNCOMPRESSED())
             case 258 -> 33;         // SECP256K1_EC_COMPRESSED())
@@ -434,6 +438,9 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return keyPairSeg;
     }
 
+    /// Construct a [SecpKeyPair]
+    /// @param keyPairSegment a segment containing a key pair
+    /// @return key pair
     private SecpKeyPair toKeyPair(MemorySegment keyPairSegment) {
         MemorySegment pubKeySegment = secp256k1_pubkey.allocate(Secp256k1Foreign.globalArena);
         int return_val = secp256k1_h.secp256k1_keypair_pub(ctx, pubKeySegment, keyPairSegment);

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -56,9 +56,7 @@ import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.SECP256K1_EC_UNCOMPRESS
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.secp256k1_schnorrsig_sign32;
 import static org.bitcoinj.secp.ffm.jextract.secp256k1_h.secp256k1_xonly_pubkey_serialize;
 
-/**
- * Implementation of {@link Secp256k1} using the {@code secp256k1} C-language library and the Java Foreign Function &amp; Memory API.
- */
+/// Implementation of [Secp256k1] using the `secp256k1` C-language library and the Java Foreign Function & Memory API.
 public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final Arena arena;
@@ -79,9 +77,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         }
     }
 
-    /**
-     * TBD: Static verify method that doesn't require a class instance.
-     */
+    /// TBD: Static verify method that doesn't require a class instance.
     public static boolean ecdsaVerify(MemorySegment sig, MemorySegment msg_hash, MemorySegment pubkey) {
         //MemorySegment msg_hash = arena.allocateArray(JAVA_BYTE, msg_hash_data);
     /* Bonus example: if all we need is signature verification (and no key
@@ -235,13 +231,11 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
 
-    /**
-     * Since {@code PubKeyData} is serializable without using the native lib, this method
-     * serialized without a native call.
-     * @param pubKey
-     * @param flags
-     * @return
-     */
+    /// Since `PubKeyData` is serializable without using the native lib, this method
+    /// serialized without a native call.
+    /// @param pubKey
+    /// @param flags
+    /// @return
     @Override
     public byte[] ecPubKeySerialize(SecpPubKey pubKey, int flags) {
         boolean compressed = switch(flags) {
@@ -321,12 +315,10 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return SecpResult.checked(return_val, () -> new EcdsaSignatureImpl(serSigSeg.toArray(JAVA_BYTE)));
     }
 
-    /**
-     * ECDSA signing with Low-R grinding. Will potentially sign multiple times until a low-R signature is generated.
-     * @param msg_hash_data hashed message data
-     * @param privKey private key
-     * @return A result, which on success contains a valid signature with a low R value.
-     */
+    /// ECDSA signing with Low-R grinding. Will potentially sign multiple times until a low-R signature is generated.
+    /// @param msg_hash_data hashed message data
+    /// @param privKey private key
+    /// @return A result, which on success contains a valid signature with a low R value.
     @Override
     public SecpResult<EcdsaSignature> ecdsaSignLowR(byte[] msg_hash_data, SecpPrivKey privKey) {
         checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
@@ -407,13 +399,11 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return schnorrSigSign32(messageHash, privKey, auxiliary_rand);
     }
 
-    /**
-     * schnorrSigSign32 using provided randomness. This is not part of the API and is intended for testing.
-     * @param messageHash message hash
-     * @param privKey private key
-     * @param auxiliaryRandom auxiliary randomness (typically from a test vector)
-     * @return the signature
-     */
+    /// schnorrSigSign32 using provided randomness. This is not part of the API and is intended for testing.
+    /// @param messageHash message hash
+    /// @param privKey private key
+    /// @param auxiliaryRandom auxiliary randomness (typically from a test vector)
+    /// @return the signature
     public SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpPrivKey privKey, byte[] auxiliaryRandom) {
         checkArg(messageHash.length == 32, "Message must be 32-byte (hash)");
         checkArg(auxiliaryRandom.length == 32, "auxiliaryRandom must be 32-byte)");
@@ -481,12 +471,9 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return "Secp256k1/" + ProviderId.LIBSECP256K1_FFM;
     }
 
-    /**
-     *
-     * @param allocator allocator to create segment with
-     * @param size size in bytes of random data
-     * @return A newly-allocated memory segment full of random data
-     */
+    /// @param allocator allocator to create segment with
+    /// @param size size in bytes of random data
+    /// @return A newly-allocated memory segment full of random data
     private static MemorySegment fill_random(SegmentAllocator allocator, int size) {
         byte[] data = new byte[size];
         secureRandom.nextBytes(data);

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -61,7 +61,6 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final Arena arena;
     private final MemorySegment ctx;
-    /* package */ static final Arena globalArena = Arena.ofAuto();
     /* package */ static final MemorySegment secp256k1StaticContext = secp256k1_h.secp256k1_context_static();
     private static final MemorySegment NULL = MemorySegment.ofAddress(0L);
     private static final SecureRandom secureRandom;
@@ -256,8 +255,8 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
             case 258 -> 33;         // SECP256K1_EC_COMPRESSED())
             default -> throw new IllegalArgumentException();
         };
-        MemorySegment serialized_pubkey = globalArena.allocate(byteSize);
-        MemorySegment lenSegment = globalArena.allocate(secp256k1_h.size_t);
+        MemorySegment serialized_pubkey = arena.allocate(byteSize);
+        MemorySegment lenSegment = arena.allocate(secp256k1_h.size_t);
         lenSegment.set(secp256k1_h.size_t, 0, serialized_pubkey.byteSize());
         int return_val = secp256k1_h.secp256k1_ec_pubkey_serialize(secp256k1StaticContext,
                 serialized_pubkey,
@@ -432,11 +431,11 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     /// @param keyPairSegment a segment containing a key pair
     /// @return key pair
     private SecpKeyPair toKeyPair(MemorySegment keyPairSegment) {
-        MemorySegment pubKeySegment = secp256k1_pubkey.allocate(Secp256k1Foreign.globalArena);
+        MemorySegment pubKeySegment = secp256k1_pubkey.allocate(arena);
         int return_val = secp256k1_h.secp256k1_keypair_pub(ctx, pubKeySegment, keyPairSegment);
         assert(return_val == 1);
         SecpPubKey pubKey = toSecpPubKey(pubKeySegment);
-        MemorySegment privKeySegment = Secp256k1Foreign.globalArena.allocate(32);
+        MemorySegment privKeySegment = arena.allocate(32);
         int return_val2 = secp256k1_h.secp256k1_keypair_sec(ctx, privKeySegment, keyPairSegment);
         assert(return_val2 == 1);
         SecpPrivKey privKey = SecpPrivKey.of(privKeySegment.toArray(JAVA_BYTE));

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -152,7 +152,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     /// Convert a pubKey [MemorySegment] to a [SecpPubKeyImpl]
-    static private SecpPubKeyImpl toSecpPubKey(MemorySegment pubKeySegment) {
+    private SecpPubKeyImpl toSecpPubKey(MemorySegment pubKeySegment) {
         MemorySegment serialized_pubkey = pubKeySerializeSegment(pubKeySegment, SECP256K1_EC_UNCOMPRESSED());
         return new SecpPubKeyImpl(serializedPubKeyToPoint(serialized_pubkey));
     }
@@ -250,7 +250,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     /// @param pubKeySegment pubKey in internal format
     /// @param flags flags for serialization
     /// @return serialized pubKey
-    static MemorySegment pubKeySerializeSegment(MemorySegment pubKeySegment, int flags) {
+    MemorySegment pubKeySerializeSegment(MemorySegment pubKeySegment, int flags) {
         int byteSize = switch(flags) {
             case 2 -> 65;           // SECP256K1_EC_UNCOMPRESSED())
             case 258 -> 33;         // SECP256K1_EC_COMPRESSED())


### PR DESCRIPTION
This PR removes a static `globalArena` variable (that actually holds an `Arena.ofShared()`). This arena was added to allow two static methods to allocate `MemorySegments`, but it would be better to just make those methods instance methods and use the same `arena` as all the other instance methods.

This is in preparation for switching to `Arena.ofConfined()` for most of the temporary `MemorySegments` used for calling native functions within a single call-frame.

4 commits:

* 2 Javadoc-only changes
* Refactor two methods to instance from `static` in preparation for 4th commit
* Update those two methods to use the instance `arena`