### PR TITLE
Secp256k1Foreign: remove package-visibility marker comments

### DIFF
--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -61,7 +61,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final Arena arena;
     private final MemorySegment ctx;
-    /* package */ static final MemorySegment secp256k1StaticContext = secp256k1_h.secp256k1_context_static();
+    static final MemorySegment secp256k1StaticContext = secp256k1_h.secp256k1_context_static();
     private static final MemorySegment NULL = MemorySegment.ofAddress(0L);
     private static final SecureRandom secureRandom;
     static {
@@ -142,7 +142,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return toSecpPubKey(pubKey);
     }
 
-    /* package */ MemorySegment ecPubKeyCreate(MemorySegment privkeySegment) {
+    MemorySegment ecPubKeyCreate(MemorySegment privkeySegment) {
         /* Public key creation using a valid context with a verified private key should never fail */
         MemorySegment pubkey = secp256k1_pubkey.allocate(arena);
         int return_val = secp256k1_h.secp256k1_ec_pubkey_create(ctx, pubkey, privkeySegment);


### PR DESCRIPTION
I was using `/* package */` where the visibility keyword like `private` would be in order  to emphasize that I had deliberately chosen the default (package) visibility, but this is unnecessary and redundant.

They either are package-visible or they are not. The intention and need at the time the comment was added may not longer be valid/true.