### PR TITLE
SecpPrivKeyNative implementation for `secp-ffm`

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPrivKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPrivKeyImpl.java
@@ -27,7 +27,9 @@ import java.util.Arrays;
 
 /**
  * Default/internal implementation of {@link SecpPrivKey}
+ * @deprecated Use methods in {@link org.bitcoinj.secp.Secp256k1} to create or import private keys.
  */
+@Deprecated
 public class SecpPrivKeyImpl implements SecpPrivKey {
     /**
      * private key or null if key was destroyed

--- a/secp-api/src/test/java/org/bitcoinj/secp/internal/SecpPrivKeyImplTest.java
+++ b/secp-api/src/test/java/org/bitcoinj/secp/internal/SecpPrivKeyImplTest.java
@@ -86,16 +86,4 @@ public class SecpPrivKeyImplTest {
                 () -> SecpScalarImpl.checkInRange(bytes)
         );
     }
-
-    @Test
-    void privateKeySerializationThrows() {
-        assertThrows(NotSerializableException.class, () -> {
-            var priv = new SecpPrivKeyImpl(BigInteger.ONE);
-
-            var baos = new ByteArrayOutputStream();
-            try (var oos = new ObjectOutputStream(baos)) {
-                oos.writeObject(priv);
-            }
-        });
-    }
 }

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -31,7 +31,6 @@ import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.EcdsaSignatureImpl;
 import org.bitcoinj.secp.internal.SecpKeyPairImpl;
 import org.bitcoinj.secp.internal.SecpPointUncompressed;
-import org.bitcoinj.secp.internal.SecpPrivKeyImpl;
 import org.bitcoinj.secp.internal.SecpPubKeyImpl;
 import org.bitcoinj.secp.ffm.jextract.secp256k1_ecdsa_signature;
 import org.bitcoinj.secp.ffm.jextract.secp256k1_h;
@@ -153,7 +152,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
             do {
                 privKeySeg = fill_random(ta, 32);
             } while (secp256k1_h.secp256k1_ec_seckey_verify(ctx, privKeySeg) != 1);
-            SecpPrivKey privKey = new SecpPrivKeyImpl(privKeySeg.toArray(JAVA_BYTE));
+            SecpPrivKey privKey = new SecpPrivKeyNative(privKeySeg);
             privKeySeg.fill((byte) 0x00);
             return privKey;
         }
@@ -161,21 +160,21 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
 
     @Override
     public SecpPrivKey ecPrivKeyImport(BigInteger privKeyInt) {
-        return new SecpPrivKeyImpl(privKeyInt);
+        return new SecpPrivKeyNative(SecpScalarImpl.integerTo32Bytes(privKeyInt));
     }
 
     @Override
     public SecpPrivKey ecPrivKeyImport(byte[] privKeyBytes) {
-        return new SecpPrivKeyImpl(privKeyBytes);
+        return new SecpPrivKeyNative(privKeyBytes);
     }
 
     @Override
     public SecpPubKey ecPubKeyCreate(SecpPrivKey privkey) {
         try (Arena ta = Arena.ofConfined()) {
 // Should we verify the key here for safety? (Probably)
-            MemorySegment privkeySegment = ta.allocateFrom(JAVA_BYTE, privkey.getEncoded());
+            MemorySegment privkeySegment = privKeySeg(ta, privkey);
             MemorySegment pubKey = ecPubKeyCreate(ta, privkeySegment);
-            privkeySegment.fill((byte) 0x00);
+            zeroIfWriteable(privkeySegment);
             // Return serialized pubkey
             return toSecpPubKey(ta, pubKey);
         }
@@ -227,9 +226,9 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     public SecpKeyPair ecKeyPairCreate(SecpPrivKey privKey) {
         try (Arena ta = Arena.ofConfined()) {
             MemorySegment keyPairSeg = secp256k1_keypair.allocate(ta);
-            MemorySegment privKeySeg = ta.allocateFrom(JAVA_BYTE, privKey.getEncoded());
+            MemorySegment privKeySeg = privKeySeg(ta, privKey);
             int return_val = secp256k1_h.secp256k1_keypair_create(ctx, keyPairSeg, privKeySeg);
-            privKeySeg.fill((byte) 0x00);
+            zeroIfWriteable(privKeySeg);
             assert(return_val == 1);
             // TODO: Parse keyPairSeg into standard SecpKeyPairImpl
             SecpKeyPair keyPair = toKeyPair(ta, keyPairSeg);
@@ -368,9 +367,9 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
             MemorySegment msg_hash = ta.allocateFrom(JAVA_BYTE, msg_hash_data);
             MemorySegment sig = secp256k1_ecdsa_signature.allocate(ta);          // internal signature format
             MemorySegment serSigSeg = secp256k1_ecdsa_signature.allocate(ta);    // serialized signature format
-            MemorySegment privKeySeg = ta.allocateFrom(JAVA_BYTE, privKey.getEncoded());
+            MemorySegment privKeySeg = privKeySeg(ta, privKey);
             int return_val = secp256k1_h.secp256k1_ecdsa_sign(ctx, sig, msg_hash, privKeySeg, NULL, NULL);
-            privKeySeg.fill((byte) 0x00);
+            zeroIfWriteable(privKeySeg);
             secp256k1_h.secp256k1_ecdsa_signature_serialize_compact(ctx, serSigSeg, sig);
             return SecpResult.checked(return_val, () -> new EcdsaSignatureImpl(serSigSeg.toArray(JAVA_BYTE)));
         }
@@ -385,7 +384,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
         try (Arena ta = Arena.ofConfined()) {
             MemorySegment msg_hash = ta.allocateFrom(JAVA_BYTE, msg_hash_data);
-            MemorySegment privKeySeg = ta.allocateFrom(JAVA_BYTE, privKey.getEncoded());
+            MemorySegment privKeySeg = privKeySeg(ta, privKey);
             MemorySegment sig = secp256k1_ecdsa_signature.allocate(ta);  // internal signature format
             MemorySegment serSigSeg = secp256k1_ecdsa_signature.allocate(ta);  // serialized signature format
             MemorySegment nonce = null;
@@ -405,7 +404,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
                 count++;
                 secp256k1_h.secp256k1_ecdsa_signature_serialize_compact(ctx, serSigSeg, sig);
             } while (return_val == OK && !hasLowR(serSigSeg)); // Retry until we get an error or low-R
-            privKeySeg.fill((byte) 0x00);
+            zeroIfWriteable(privKeySeg);
             return SecpResult.checked(return_val, () -> new EcdsaSignatureImpl(serSigSeg.toArray(JAVA_BYTE)));
         }
     }
@@ -501,6 +500,22 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         return SchnorrSignatureImpl.of(sig.toArray(JAVA_BYTE));
     }
 
+
+    /// Get a segment with a private key in it. If `privKey` is an [SecpPrivKeyNative] we return
+    /// the read-only segment provided by [SecpPrivKeyNative#segment()], otherwise we allocate
+    /// a temporary segment, that should be zero-filled after use by [Secp256k1Foreign#zeroIfWriteable(MemorySegment)]
+    /// @param alloc allocator (arena) to use if we need to allocate a temporary segment
+    /// @param privKey a private key
+    /// @return private key segment (writable if temporary copy)
+    private MemorySegment privKeySeg(SegmentAllocator alloc, SecpPrivKey privKey) {
+        if (privKey instanceof SecpPrivKeyNative privKeyFfm) {
+            return privKeyFfm.segment();
+        } else {
+            // TODO: zero temporary array copy
+            return alloc.allocateFrom(JAVA_BYTE, privKey.getEncoded());
+        }
+    }
+
     /// Create a `secp256k1_keypair` segment from a [SecpPrivKey]
     /// @param alloc allocator to create segments with
     /// @param privKey private key
@@ -526,7 +541,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
         MemorySegment privKeySegment = alloc.allocate(32);
         int return_val2 = secp256k1_h.secp256k1_keypair_sec(ctx, privKeySegment, keyPairSegment);
         assert(return_val2 == 1);
-        SecpPrivKey privKey = new SecpPrivKeyImpl(privKeySegment.toArray(JAVA_BYTE));
+        SecpPrivKey privKey = new SecpPrivKeyNative(privKeySegment);
         privKeySegment.fill((byte) 0x00);
         return new SecpKeyPairImpl(privKey, pubKey);
     }
@@ -551,10 +566,10 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
             SecpResult<MemorySegment> parsedPubKey = pubKeyParse(ta, pubKey);
             if (parsedPubKey instanceof SecpResult.Err<MemorySegment> err) return SecpResult.err(err.code());
             MemorySegment pubKeySeg = parsedPubKey.get();  // Get pubkey in 64-byte internal format
-            MemorySegment privKeySeg = ta.allocateFrom(JAVA_BYTE, privKey.getEncoded());
+            MemorySegment privKeySeg = privKeySeg(ta, privKey);
             MemorySegment output = ta.allocate(32);
             int success = secp256k1_h.secp256k1_ecdh(ctx, output, pubKeySeg, privKeySeg, NULL, NULL);
-            privKeySeg.fill((byte) 0x00);
+            zeroIfWriteable(privKeySeg);
             return SecpResult.checked(success, () -> new EcdhSharedSecretImpl(output.toArray(JAVA_BYTE)));
         }
     }
@@ -631,6 +646,15 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     @Override
     public String toString() {
         return "Secp256k1/" + ProviderId.LIBSECP256K1_FFM;
+    }
+
+    /// Fill writeable (temporary) segments with zeros. In this context, non-temporary segments are read-only
+    /// so they shouldn't (and can't) be erased.
+    /// @param segment a segment to zero if writeable/temporary
+    private void zeroIfWriteable(MemorySegment segment) {
+        if (!segment.isReadOnly()) {
+            segment.fill((byte) 0x00);
+        }
     }
 
     /// @param allocator allocator to create segment with

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/SecpPrivKeyNative.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/SecpPrivKeyNative.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.ffm;
+
+import org.bitcoinj.secp.SecpPrivKey;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
+import org.bitcoinj.secp.internal.UInt256;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+
+/// Native implementation of SecpPrivKey
+class SecpPrivKeyNative implements SecpPrivKey {
+    private static final int KEY_LENGTH = 32;
+
+    private volatile boolean destroyed = false;
+    private final MemorySegment segment;
+
+    SecpPrivKeyNative(MemorySegment privKeySeg) {
+        var segment = Arena.ofAuto().allocate(KEY_LENGTH);
+        MemorySegment.copy(privKeySeg, 0, segment, 0, KEY_LENGTH);
+        this.segment = segment;
+    }
+
+    SecpPrivKeyNative(byte[] privKeyBytes) {
+        SecpScalarImpl.checkInRange(privKeyBytes);
+        this(MemorySegment.ofArray(privKeyBytes));
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        if (destroyed) throwKeyDestroyed();
+        return segment.toArray(JAVA_BYTE);
+    }
+
+    @Override
+    public BigInteger getS() {
+        if (destroyed) throwKeyDestroyed();
+        byte[] bytes = getEncoded();
+        try {
+            return UInt256.toBigInteger(bytes);
+        } finally {
+            Arrays.fill(bytes, (byte) 0);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // TODO: Make sure the zeroing is not optimized out by the compiler or JIT
+        if (!destroyed) {
+            segment.fill((byte) 0);
+            destroyed = true;
+        }
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+
+    MemorySegment segment() {
+        if (destroyed) throwKeyDestroyed();
+        return segment.asReadOnly();
+    }
+
+    private void throwKeyDestroyed() {
+        throw new IllegalStateException("Private Key has been destroyed");
+    }
+
+    @Serial
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        throw new NotSerializableException("Serialization of private keys is prohibited.");
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        throw new NotSerializableException("Deserialization of private keys is prohibited.");
+    }
+}

--- a/secp-ffm/src/test/java/org/bitcoinj/secp/ffm/SecpPrivKeyNativeTest.java
+++ b/secp-ffm/src/test/java/org/bitcoinj/secp/ffm/SecpPrivKeyNativeTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.ffm;
+
+import org.bitcoinj.secp.Secp256k1;
+import org.bitcoinj.secp.SecpPrivKey;
+import org.bitcoinj.secp.SecpPubKey;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Unit tests of [SecpPrivKeyNative]
+public class SecpPrivKeyNativeTest {
+
+    @Test
+    void constructOne() {
+        var oneInt = BigInteger.ONE;
+        var oneBytes = SecpScalarImpl.integerTo32Bytes(oneInt);
+
+        var onePrivKey = new SecpPrivKeyNative(oneBytes);
+        assertEquals(oneInt, onePrivKey.getS());
+
+        var onePrivKeyClone = new SecpPrivKeyNative(onePrivKey.segment());
+        assertEquals(oneInt, onePrivKeyClone.getS());
+
+        onePrivKeyClone.destroy();
+        assertTrue(onePrivKeyClone.isDestroyed());
+        assertFalse(onePrivKey.isDestroyed());
+    }
+
+    @Test
+    void constructAndDestroy() {
+        try (Secp256k1Foreign secp = new Secp256k1Foreign()) {
+            SecpPrivKey privKey = secp.ecPrivKeyCreate();
+            assertFalse(privKey.isDestroyed());
+            privKey.destroy();
+            assertTrue(privKey.isDestroyed());
+
+            assertThrows(IllegalStateException.class, privKey::getS);
+            assertThrows(IllegalStateException.class, () -> ((SecpPrivKeyNative)privKey).segment());
+        }
+    }
+
+    @Test
+    void multiplyTestOne() {
+        try (Secp256k1Foreign secp = new Secp256k1Foreign()) {
+            SecpPrivKey onePrivKey = new SecpPrivKeyNative(SecpScalarImpl.integerTo32Bytes(BigInteger.ONE));
+            SecpPubKey pubKey = secp.ecPubKeyCreate(onePrivKey);
+            SecpPubKey check = secp.ecPubKeyTweakMul(Secp256k1.G, onePrivKey.getS());
+            assertEquals(pubKey.x(), check.x());
+            assertEquals(pubKey.y(), check.y());
+        }
+    }
+
+    @Test
+    void multiplyTest() {
+        try (Secp256k1Foreign secp = new Secp256k1Foreign()) {
+            SecpPrivKey privKey = secp.ecPrivKeyCreate();
+            SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
+            SecpPubKey check = secp.ecPubKeyTweakMul(Secp256k1.G, privKey.getS());
+            assertEquals(pubKey.x(), check.x());
+            assertEquals(pubKey.y(), check.y());
+        }
+    }
+
+}


### PR DESCRIPTION
The first commit of this PR adds `SecpPrivKeyNative`, the second deprecates `SecpPrivKeyImpl`.

I have extracted the WIP `SecpPubKeyNative` work from this branch and it is now in:

* PR #547 
