### PR TITLE
SecpPrivKeyBc: Bouncy Castle/BigInteger impl of SecpPrivKey

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpScalarImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpScalarImpl.java
@@ -59,7 +59,7 @@ public class SecpScalarImpl implements SecpScalar {
      * @param e unvalidated integer ({@code byte[]} format)
      * @return a validated integer ({@code byte[]} format)
      */
-    static byte[] checkInRange(byte[] e) {
+    public static byte[] checkInRange(byte[] e) {
         if (e.length != 32) {
             throw new IllegalArgumentException("SecpScalar must have 32 bytes, found : " + e.length);
         }

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -25,6 +25,7 @@ import org.bitcoinj.secp.SecpXOnlyPubKey;
 import org.bitcoinj.secp.SchnorrSignature;
 import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.internal.ByteArray;
 import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.EcdsaSignatureImpl;
 import org.bitcoinj.secp.internal.SchnorrSignatureImpl;
@@ -115,17 +116,17 @@ public class Bouncy256k1 implements Secp256k1 {
     @Override
     public SecpPrivKey ecPrivKeyCreate() {
         BigInteger privKey = ((ECPrivateKeyParameters) bcKeyPairCreate().getPrivate()).getD();
-        return SecpPrivKey.of(privKey);
+        return new SecpPrivKeyBc(privKey);
     }
 
     @Override
     public SecpPrivKey ecPrivKeyImport(BigInteger privKeyInt) {
-        return new SecpPrivKeyImpl(privKeyInt);
+        return SecpPrivKeyBc.of(privKeyInt);
     }
 
     @Override
     public SecpPrivKey ecPrivKeyImport(byte[] privKeyBytes) {
-        return new SecpPrivKeyImpl(privKeyBytes);
+        return SecpPrivKeyBc.of(ByteArray.toInteger(SecpScalarImpl.checkInRange(privKeyBytes)));
     }
 
     @Override

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpPrivKeyBc.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpPrivKeyBc.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.bouncy;
+
+import org.bitcoinj.secp.SecpPrivKey;
+import org.bitcoinj.secp.SecpScalar;
+import org.bitcoinj.secp.internal.ByteArray;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.math.BigInteger;
+
+/**
+ * Private key implementation that stores the private key as a {@link BigInteger}.
+ */
+public class SecpPrivKeyBc implements SecpPrivKey {
+    private @Nullable BigInteger privKey;
+
+    // Unchecked, for internal-use only
+    SecpPrivKeyBc(BigInteger privKey) {
+        this.privKey = privKey;
+    }
+
+    // Checked, use for import, etc.
+    static SecpPrivKeyBc of(BigInteger privKey) {
+         return new SecpPrivKeyBc(SecpScalar.checkInRange(privKey));
+    }
+
+    // Checked, use for import, etc.
+    static SecpPrivKeyBc of(byte[] privKeyBytes) {
+        return new SecpPrivKeyBc(ByteArray.toInteger(SecpScalarImpl.checkInRange(privKeyBytes)));
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        if (privKey == null) throwKeyDestroyed();
+        return SecpScalarImpl.integerTo32Bytes(privKey);
+    }
+
+    @Override
+    public BigInteger getS() {
+        if (privKey == null) throwKeyDestroyed();
+        return privKey;
+    }
+
+    @Override
+    public void destroy() {
+        privKey = null;
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return privKey == null;
+    }
+
+    private void throwKeyDestroyed() {
+        throw new IllegalStateException("Private Key has been destroyed");
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        throw new NotSerializableException("Serialization of private keys is prohibited.");
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        throw new NotSerializableException("Deserialization of private keys is prohibited.");
+    }
+}


### PR DESCRIPTION
This first commit minimizes copying and conversion of SecpPrivKey for BC. It needs more comments and tests.

The second commit is more WIP and starts adding a MemorySegment `SecpPubKey` implementation, but I'm still uncertain what is the best choice for an internal format for that implementation and how best to do the conversions to the other formats returned by the various getters.

More design and analysis needs to happen.