### PR TITLE
Prepare Release 0.3.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,65 @@
 
 A high-level view of the changes in each secp256k1-jdk binary release.
 
+== v0.3.1
+
+See the instructions in the README for accessing the binary via the GitLab Maven repository. A future release of secp25k1-jdk will be in Maven Central.
+
+=== API Changes
+
+* `SecpXOnlyPubKeyImpl`: implement `equals()` and `hashCode()` -- https://github.com/bitcoinj/secp256k1-jdk/pull/438[PR #438]
+* `SecpKeyPair`, `SecpPoint`: deprecate unused, unvalidated constructors -- https://github.com/bitcoinj/secp256k1-jdk/pull/448[PR #448]
+* `secp-ffm`: drop export of internal `o.b.s.ffm.jextract` package -- https://github.com/bitcoinj/secp256k1-jdk/pull/446[PR #446]
+* `o.b.s.ffm` package-info: reflect JDK 25+ requirement -- https://github.com/bitcoinj/secp256k1-jdk/pull/447[PR #447]
+
+=== Validation and Hardening
+
+* `SecpPrivKey`, `SecpFieldElement`: add defensive copy of `byte[]` in `of()` -- https://github.com/bitcoinj/secp256k1-jdk/pull/437[PR #437], https://github.com/bitcoinj/secp256k1-jdk/pull/439[PR #439]
+* `Secp256k1Foreign`, `Secp256k1Bouncy`: validate ECDSA message hashes are 32 bytes -- https://github.com/bitcoinj/secp256k1-jdk/pull/440[PR #440]
+* `Secp256k1Foreign`: validate `auxiliaryRandom` is 32 bytes -- https://github.com/bitcoinj/secp256k1-jdk/pull/442[PR #442]
+* `SecpPrivKeyImpl`: prevent serialization by throwing `NotSerializableException` -- https://github.com/bitcoinj/secp256k1-jdk/pull/441[PR #441]
+
+=== Bug fixes
+
+* `SecpKeyPairImpl`: fix `isDestroyed()` to query the underlying private key rather than always returning `false` -- https://github.com/bitcoinj/secp256k1-jdk/pull/443[PR #443]
+* `Secp256k1Foreign`: make `close()` idempotent -- https://github.com/bitcoinj/secp256k1-jdk/pull/445[PR #445]
+* `ForeignRegistrationFeature`: add missing downcall registration, fixing a native-image runtime failure in the `ecdsa-example` -- https://github.com/bitcoinj/secp256k1-jdk/pull/478[PR #478]
+
+=== Bouncy Castle Implementation
+
+* Use Bouncy Castle's `BIP340Signer` for Schnorr Signatures -- https://github.com/bitcoinj/secp256k1-jdk/pull/467[PR #467]
+
+=== Schnorr / libsecp256k1 (FFM) Implementation
+
+* `Secp256k1Foreign`: optimize `signLowR` -- https://github.com/bitcoinj/secp256k1-jdk/pull/468[PR #468]
+* `Secp256k1Foreign`: use `Arena.ofConfined()` for all allocation, remove static `globalArena` -- https://github.com/bitcoinj/secp256k1-jdk/pull/479[PR #479], https://github.com/bitcoinj/secp256k1-jdk/pull/469[PR #469]
+
+=== Testing Improvements
+
+* `SchnorrTest`: parameterize to test with both FFM and Bouncy Castle -- https://github.com/bitcoinj/secp256k1-jdk/pull/449[PR #449]
+* `SecpPrivKeyTest`: add integration test of construct, destroy -- https://github.com/bitcoinj/secp256k1-jdk/pull/483[PR #483]
+
+=== Build and Test Improvements
+
+* GHA `build.yml`: add native build/run for the `ecdsa-example`, remove duplicate verify lifecycle phase, fix `CI_REVISION` using `sed` -- https://github.com/bitcoinj/secp256k1-jdk/pull/478[PR #478], https://github.com/bitcoinj/secp256k1-jdk/pull/477[PR #477], https://github.com/bitcoinj/secp256k1-jdk/pull/429[PR #429]
+* `flake.nix`: simplify `forEachSystem` with `nixpkgs.lib.genAttrs` -- https://github.com/bitcoinj/secp256k1-jdk/pull/435[PR #435]
+* `maven-publish-release.sh`: add `--dry-run` option, set `JRELEASER_OUTPUT_DIRECTORY`; output flattened pom to `target` -- https://github.com/bitcoinj/secp256k1-jdk/pull/431[PR #431], https://github.com/bitcoinj/secp256k1-jdk/pull/430[PR #430]
+* `dependabot.yml`: switch package-ecosystem to "maven", raise concurrent pull request limit to 10, only update `org.graalvm.sdk` on patch versions -- https://github.com/bitcoinj/secp256k1-jdk/pull/455[PR #455], https://github.com/bitcoinj/secp256k1-jdk/pull/475[PR #475], https://github.com/bitcoinj/secp256k1-jdk/pull/463[PR #463]
+
+=== Dependency Updates
+
+* `flake.nix`: update Nixpkgs from `6b31628` to `8623c4c` (multiple dependabot updates) -- https://github.com/bitcoinj/secp256k1-jdk/pull/432[PR #432], https://github.com/bitcoinj/secp256k1-jdk/pull/436[PR #436], https://github.com/bitcoinj/secp256k1-jdk/pull/444[PR #444], https://github.com/bitcoinj/secp256k1-jdk/pull/451[PR #451], https://github.com/bitcoinj/secp256k1-jdk/pull/465[PR #465], https://github.com/bitcoinj/secp256k1-jdk/pull/481[PR #481]
+* `secp-bouncy`: update Bouncy Castle to 1.85 -- https://github.com/bitcoinj/secp256k1-jdk/pull/456[PR #456]
+* Update Kotlin to 2.4.10 (`kotlin-maven-plugin`, `kotlin-stdlib`) -- https://github.com/bitcoinj/secp256k1-jdk/pull/458[PR #458], https://github.com/bitcoinj/secp256k1-jdk/pull/473[PR #473]
+* Update JUnit to 6.1.2 -- https://github.com/bitcoinj/secp256k1-jdk/pull/461[PR #461]
+* Update GraalVM `nativeimage` to 25.0.4, `native-build-tools` to 1.1.5 -- https://github.com/bitcoinj/secp256k1-jdk/pull/472[PR #472], https://github.com/bitcoinj/secp256k1-jdk/pull/459[PR #459]
+* Update `maven-surefire-plugin` and `maven-surefire-report-plugin` to 3.5.6 -- https://github.com/bitcoinj/secp256k1-jdk/pull/464[PR #464], https://github.com/bitcoinj/secp256k1-jdk/pull/462[PR #462]
+* Update `maven-jar-plugin` to 3.5.1 -- https://github.com/bitcoinj/secp256k1-jdk/pull/470[PR #470]
+* Update `license-maven-plugin` to 5.1.1 -- https://github.com/bitcoinj/secp256k1-jdk/pull/471[PR #471]
+* Update `flatten-maven-plugin` to 1.8.0 -- https://github.com/bitcoinj/secp256k1-jdk/pull/480[PR #480]
+
+WARNING: This is pre-alpha software and unaudited. Please use with extreme caution and do not use on Bitcoin MAINNET.
+
 == v0.3
 
 Released: 2026-06-07

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ WARNING:: This prototype software has had limited testing and has not been revie
 == API
 
 The API is based on the `C-language` API of https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1], but adapted
-to modern, idiomatic, functional-style Java. and to use Elliptic Curve types from the Java Class Library, such as https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/interfaces/ECPublicKey.html[ECPublicKey] where appropriate.
+to modern, idiomatic, functional-style Java. It also can convert to and from Elliptic Curve types in the Java Class Library, such as https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/security/spec/ECPoint.html[ECPoint] where appropriate.
 
 The API is distributed as an API-only JAR (```secp-api-{secp-jdk-version}.jar```) and there are multiple implementations of the API. `secp-api` requires JDK 9 or later.
 
@@ -31,8 +31,7 @@ NOTE:: At this point, we are especially interested in feedback on the API.
 
 The provided implementation uses the https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1] C-language library via https://openjdk.org/jeps/454[JEP-454: Foreign Function & Memory API] (known as **Panama**.) It is provided in a separate JAR (```secp-ffm-{secp-jdk-version}.jar```) that requires JDK 25 or later.
 
-Panama was released as part of https://openjdk.org/projects/jdk/22/[OpenJDK 22]. We anticipate `secp-ffm` will be
-the recommended/preferred `secp-api` implementation for use in projects using modern JVMs.
+We recommend `secp-ffm` as the preferred `secp-api` implementation for use in projects using modern JVMs.
 
 The minimum required JDK for the `secp-ffm` module is JDK 25 (the first LTS release with FFM included.)
 
@@ -40,13 +39,13 @@ WARNING:: This is a preliminary implementation provided for experimentation and 
 
 == Bouncy Castle Implementation
 
-A https://www.bouncycastle.org[Bouncy Castle]-based submodule is included. Bouncy Castle is a well-regarded cryptography library that includes support for the secp256k1 curve and is currently used by https://bitcoinj.org[bitcoinj] and other Java-based Bitcoin implementations. We expect this implementation to be completed and made available as a pure-Java implementation for those who are unable to use the FFM-based libsecp256k1 implementation.
+A https://www.bouncycastle.org[Bouncy Castle]-based submodule is included. Bouncy Castle is a well-regarded cryptography library that includes support for the secp256k1 curve and is currently used by https://bitcoinj.org[bitcoinj] and other Java-based Bitcoin implementations. The `secp-bouncy` module provides a pure-Java implementation for those who are unable to use the FFM-based libsecp256k1 implementation.
 
 The Bouncy Castle implementation works with JDK 9 or later.
 
 == libsecp256k1 Implementation for older JDKs
 
-There are currently _no plans_ for an implementation using earlier Java-to-C adapter technologies such as https://docs.oracle.com/en/java/javase/21/docs/specs/jni/index.html[JNI] or https://github.com/java-native-access/jna[JNA]. However, the `secp256k1-jdk` API will support a JNI implementation. We would be supportive if someone in the community endeavors to create an implementation or adapt one of the existing implementations to use the `secp256k1-jdk` API.
+There are currently _no plans_ for an implementation using earlier Java-to-C adapter technologies such as https://docs.oracle.com/en/java/javase/21/docs/specs/jni/index.html[JNI] or https://github.com/java-native-access/jna[JNA]. However, the `secp256k1-jdk` API can support a JNI implementation. We would be supportive if someone in the community endeavors to create an implementation or adapt one of the existing implementations to use the `secp256k1-jdk` API.
 
 == Relation to bitcoinj
 
@@ -156,25 +155,31 @@ or for GraalVM builds:
 
 ==== Using the Nix devShell
 
-The Nix devshell sets up everything correctly, so simply run `nix develop` and you can build and run.
+The Nix devshell sets up everything correctly, so simply run `nix develop` and you'll be ready to build and run. It sets up `LD_LIBRARY_PATH` on Linux and `DYLD_LIBRARY_PATH` on macOS. It also sets `LIBSECP_DIR` which is what the Maven `pom.xml` file references.
 
 ==== Using APT
 
 * `apt-get -y install libsecp256k1-dev`
 
-This will correctly set up `LD_LIBRARY_PATH` and you can build and run.
+This will correctly set up `LD_LIBRARY_PATH`, but you'll need to set the following for `pom.xml`:
+
+[source,shell]
+----
+export LIBSECP_DIR="$LD_LIBRARY_PATH"
+----
 
 ==== Using Homebrew
 
 . `brew install secp256k1`
 . `export DYLD_LIBRARY_PATH="$(brew --prefix secp256k1)/lib:$DYLD_LIBRARY_PATH"`
-. `export JAVA_TOOL_OPTIONS="-Djava.library.path=$(brew --prefix secp256k1)/lib"`
+. `export LIBSECP_DIR="$LD_LIBRARY_PATH"`
 
-Step 2 sets up `DYLD_LIBRARY_PATH` correctly, but `DYLD_LIBRARY_PATH` https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/RuntimeProtections/RuntimeProtections.html[is cleared] by macOS https://support.apple.com/en-us/102149[System Integrity Protection] before running protected executables (notably the shell binaries typically used to start Gradle) so step 3 sets `JAVA_TOOL_OPTIONS` which Gradle and processes spawned by Gradle will pick up the correct library path.
+
+Step 2 sets up `DYLD_LIBRARY_PATH` correctly, but `DYLD_LIBRARY_PATH` https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/RuntimeProtections/RuntimeProtections.html[is cleared] by macOS https://support.apple.com/en-us/102149[System Integrity Protection] before running protected executables (notably the shell scripts used to start Maven) so step 3 sets `LIBSECP_DIR` which our Maven `pom.xml` references to pick up the correct library path.
 
 ==== Other mechanisms
 
-Other mechanisms should work as long as you set up `LD_LIBRARY_PATH` and/or `DYLD_LIBRARY_PATH` properly and are mindful of System Integrity Protection on macOS.
+Other mechanisms should work as long as you set up `LIBSECP_DIR` and `LD_LIBRARY_PATH` and/or `DYLD_LIBRARY_PATH` properly and are mindful of System Integrity Protection on macOS.
 
 ==== Bundling libsecp256k1 in a JAR at runtime
 
@@ -199,32 +204,32 @@ To build using GraalVM `native-image`:
 . Make sure you have GraalVM 25 or later installed
 . Make sure `GRAALVM_HOME` points to the Graal JDK 25 installation
 . `mvn verify -Pnative-schnorr`
+. `mvn verify -Pnative-ecdsa`
 
 Run the native image binary:
 
 . `./secp-examples-java/target/schnorr-example`
+. `./secp-examples-java/target/ecdsa-example`
 
-=== Building with Nix
-
-NOTE:: We currently only support setting up a development shell with Nix. In the future we hope to support a full Nix build.
+=== Building with the Nix Devshell
 
 To start a development shell with all build prerequisites installed and run the Gradle build:
 
 . `nix develop`
-. `mvn package`
+. `mvn verify`
 
-The other commands described in the "Building with Maven" section work in the Nix devShell.
+The other commands described in the "Building with Maven" section also work in the Nix devShell.
+
+`secp256k1-jdk` is available in Nixpkgs, see: https://search.nixos.org/packages?channel=unstable&query=secp256k1-jdk#show=secp256k1-jdk[nixpkgs#secp256k1-jdk]
 
 === Extracting Headers with Nix
-
-This is currently unsupported.
 
 To extract the libsecp256k1 headers into Java classes via `jextract` using the `extract-header.sh` script:
 
 . `nix develop`
 . `./extract-headers.sh`
 
-The extracted headers will be writen to `./build/org/bitcoinj/secp/ffm/jextract`. You can compare the generated headers with the checked-in headers with:
+The extracted headers will be writen to `./target/org/bitcoinj/secp/ffm/jextract`. You can compare the generated headers with the checked-in headers with:
 
 . `diff -r secp-ffm/src/main/java/org/bitcoinj/secp/ffm/jextract build/org/bitcoinj/secp/ffm/jextract`
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = secp256k1-jdk
-:secp-jdk-version: 0.3
+:secp-jdk-version: 0.3.1
 
 image:https://github.com/bitcoinj/secp256k1-jdk/workflows/Gradle%20Build/badge.svg[GitHub Build Status,link=https://github.com/bitcoinj/secp256k1-jdk/actions] image:https://gitlab.com/bitcoinj/secp256k1-jdk/badges/master/pipeline.svg[GitLab Build Status,link=https://gitlab.com/bitcoinj/secp256k1-jdk/-/pipelines]
 

--- a/docs/release-procedure.adoc
+++ b/docs/release-procedure.adoc
@@ -1,6 +1,6 @@
 == Maven + JReleaser Release Process
 
-. Use Java 25, Gradle 9.4.1 for official builds via Nix devShell
+. Use Java 25, Maven 3.9.12 for official builds via Nix devShell
 .. `nix develop`
 . Set versions
 .. `/project/properties/revision` in root `pom.xml`
@@ -12,6 +12,7 @@
 . Full build, test
 .. `mvn verify -Prun-schnorr,run-ecdsa,run-schnorr-kotlin,run-ecdsa-kotlin`
 .. `mvn verify -Pnative-schnorr`
+.. `mvn verify -Pnative-ecdsa`
 .. `./scripts/build-release.sh`
 . Tag: `git tag -a v0.x.y -m "Release v0.x.y"`
 . Push: `git push --tags origin <release-branch>`

--- a/extract-headers.sh
+++ b/extract-headers.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
 # This script assumes you are using Nix Packages with `experimental-features = nix-command flakes`
-# and have used `nix profile install secp256k1` to install the secp256k1 library and headers.
-# It also assumes you have `jextract` version 23 in your `$PATH`. (To install with Nix, use
-# `nix profile install jextract`)
-INC_PATH="$HOME/.nix-profile/include/"
+# and are running in the Nix devshell or have used `nix profile install secp256k1` to install the secp256k1
+# library and headers into your profile.
+# It also assumes you have `jextract` version 25 in your `$PATH` via the devshell, Nix Home Manager, or
+# `nix profile install nixpkgs#jextract`.
+# `$SECP256K1_INCLUDE_DIR` should be set to point to the header files, the Nix devshell also sets this up.
 mkdir -p build
 jextract --target-package org.bitcoinj.secp.ffm.jextract \
-        --output build \
+        --output target \
         --use-system-load-library \
         -lsecp256k1 \
         --header-class-name secp256k1_h \
-        $INC_PATH/secp256k1_schnorrsig.h \
-        $INC_PATH/secp256k1_ecdh.h
+        $SECP256K1_INCLUDE_DIR/secp256k1_schnorrsig.h \
+        $SECP256K1_INCLUDE_DIR/secp256k1_ecdh.h

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
                     jdk_headless = jdk;             # Run Maven with this JDK
                 })
             ];
+          SECP256K1_INCLUDE_DIR = "${pkgs.lib.getDev pkgs.secp256k1}/include";
           shellHook = sharedShellHook;
         };
         # define minimum devshell, with the minimum necessary to do a CI build

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </scm>
 
     <properties>
-        <revision>0.3.1-SNAPSHOT</revision>
+        <revision>0.3.1</revision>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <maven.version.minimum>3.9.0</maven.version.minimum>


### PR DESCRIPTION
Commit 1:

Update the README including build instructions.

Update flake.nix to setup the `SECP256K1_INCLUDE_DIR` env variable.

Update extract-headers.sh to use `SECP256K1_INCLUDE_DIR` and to write to the `target` directory (same as Maven)

Commit 2:

Update `CHANGELOG`, `README`, version in `pom.xml`, `release-procedure.adoc`