### PR TITLE
Tweaks to release-procedure.adoc after v0.3.1

### DIFF
--- a/docs/release-procedure.adoc
+++ b/docs/release-procedure.adoc
@@ -10,6 +10,8 @@
 . Commit version bump and `CHANGELOG`.
 . Make sure project directory is a clean checkout.
 . Full build, test
+.. `nix develop`
+.. `mvn clean`
 .. `mvn verify -Prun-schnorr,run-ecdsa,run-schnorr-kotlin,run-ecdsa-kotlin`
 .. `mvn verify -Pnative-schnorr`
 .. `mvn verify -Pnative-ecdsa`
@@ -23,3 +25,8 @@
 .. Download the `secp256k1-jdk-javadoc` artifact from the GHA Maven build
 .. Publish to https://msgilligan.github.io/javadoc/secp256k1-jdk/0.x.y/ (for now)
 . Add Release on GitHub
+
+
+== After Release
+
+. Set `/project/properties/revision` in root `pom.xml` to the `-SNAPSHOT`  of the next release.

--- a/scripts/maven-publish-release.sh
+++ b/scripts/maven-publish-release.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Validate and publish release artifacts to our GitLab Maven artifact rpo
+# Validate and publish release artifacts to our GitLab Maven artifact repo
 # This should be run from the project root directory and inside the `nix develop` shell
 # JRELEASER_GITLAB_TOKEN should be set before running
 if [[ $1 != "--dry-run" && $1 != "" ]]; then


### PR DESCRIPTION
I discovered the importance of doing a `mvn clean` as part of today's release procedure. `jreleaser-cli` will try (and fail) to push the previous release if the `target` directory is not wiped.

`jreleaser-cli` also failed to display a proper error message, see https://github.com/jreleaser/jreleaser/issues/2155.


