### PR TITLE
api-design-notes.adoc: minor updates

### DIFF
--- a/docs/api-design-notes.adoc
+++ b/docs/api-design-notes.adoc
@@ -3,13 +3,13 @@
 == Introduction
 
 `secp256k1-jdk` is a Java library providing Elliptic Curve Cryptography signing, verification and other primitives using the https://www.secg.org/[SECG] curve
-https://en.bitcoin.it/wiki/Secp256k1[secp256k1]. A major priority in the design and implementation is to provide a high-quality, industry-standard Java API for the C-language https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1] library. At the same time, it is a priority to provide an implementation-independent API to allows alternative implementations.
+https://en.bitcoin.it/wiki/Secp256k1[secp256k1]. A major priority in the design and implementation is to provide a high-quality, industry-standard Java API for the C-language https://github.com/bitcoin-core/secp256k1[bitcoin-core/secp256k1] library. At the same time, it is a priority to provide an implementation-independent API to allow alternative implementations.
 
 The `secp-api` module  (`org.bitcoinj.secp:secp-api` Maven artifact, `org.bitcoinj.secp` Java Module System module) defines the `secp256k1-jdk` API entirely using `interface` classes and allows clients of the API to be developed that are completely implementation-independent. Libraries using `secp-api` (for example a future version of **bitcoinj**) can be developed that depend on the API and allow applications to choose an implementation at runtime.
 
 The design of the `secp256k1-jdk` API is not final, but our goal is for it to become the industry standard for Java, JDK, and JVM-language Bitcoin libraries and applications.
 
-These draft _Design Notes_ are a statement of the principles and priorities of the API design. We welcome feedback on these design notes that may help us refine the priorities or explain them more clearly -- they are not yet final. The same is true of the prototype API implementation.
+These draft _Design Notes_ are a statement of the principles and priorities of our API design. We welcome feedback on these design notes that may help us refine the priorities or explain them more clearly -- they are not yet final. The same is true of the prototype API implementation.
 
 == Design Priorities
 
@@ -19,6 +19,6 @@ These draft _Design Notes_ are a statement of the principles and priorities of t
 . Strongly encourage secure usage patterns.
 . Provide an API that is implementation-independent. This means no public concrete classes in `secp-api` module and the ability to swap implementations at run-time.
 . Fully support the Java Module System (but do not require its use.)
-. Be Valhalla-friendly: key types will be value types.
-. In the initial release, support Java as old as version 8 or 9.
+. Be Valhalla-friendly: some types may become value types.
+. In the initial release, support Java as old as version 9.
 . Require near-zero dependencies. (The only dependency is JSpecify which is very minimal and needed for nullability annotations and first-class Kotlin support.)


### PR DESCRIPTION
* Backpedal on Valhalla a little: "some types _may_ become value types"
* Drop mention of Java 8 as a minimum version. We have decided on Java 9.
* Other minor edits for grammar and clarity.