### PR TITLE
Bouncy256k1, Secp256k1Foreign: make secureRandom an instance field

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -75,7 +75,7 @@ public class Bouncy256k1 implements Secp256k1 {
      */
     static final BigInteger HALF_CURVE_ORDER;
 
-    private static final SecureRandom secureRandom;
+    private final SecureRandom secureRandom;
 
     private static final byte[] TAG_AUX = "BIP0340/aux".getBytes(StandardCharsets.UTF_8);
     private static final byte[] TAG_NONCE = "BIP0340/nonce".getBytes(StandardCharsets.UTF_8);
@@ -89,7 +89,23 @@ public class Bouncy256k1 implements Secp256k1 {
                 BC_CURVE_PARAMS.getN(),
                 BC_CURVE_PARAMS.getH());
         HALF_CURVE_ORDER = BC_CURVE_PARAMS.getN().shiftRight(1);
+    }
+
+    /**
+     * Default constructor.
+     */
+    public Bouncy256k1() {
         // TODO: Verify using cryptographic random number generator properly
+        // We initialize a new `SecureRandom` per instance for the following reasons:
+        // 1. Per-instance allocation avoids the static being contained in GraalVM
+        //    native-image instances (GraalVM may special-case this) or being cloned when the
+        //    containing process is cloned (may occur with containers, etc.)
+        // 2. On certain JDK/OS configurations it's possible `SecureRandom.getInstanceStrong()`
+        //    can cause a delay. It's better to not incur this during static initialization.
+        // 3. Some implementations of `SecureRandom` may have locking contention
+        //    that could show up in a multi-threaded environment.
+        // 4. Per-instance allocation allows for override for testing or custom
+        //    configurations, though this will require adding new constructors.
         try {
             secureRandom = SecureRandom.getInstanceStrong();
         } catch (NoSuchAlgorithmException e) {
@@ -98,12 +114,6 @@ public class Bouncy256k1 implements Secp256k1 {
             // at least one strong SecureRandom implementation."
             throw new RuntimeException("No strong SecureRandom available", e);
         }
-    }
-
-    /**
-     * Default constructor.
-     */
-    public Bouncy256k1() {
     }
 
     @Override
@@ -403,7 +413,7 @@ public class Bouncy256k1 implements Secp256k1 {
      * @param size size in bytes of random data
      * @return A newly-allocated memory segment full of random data
      */
-    private static byte[] fillRandom(int size) {
+    private byte[] fillRandom(int size) {
         byte[] data = new byte[size];
         secureRandom.nextBytes(data);
         return data;

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -77,18 +77,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     private final MemorySegment ctx;
     static final MemorySegment secp256k1StaticContext = secp256k1_h.secp256k1_context_static();
     private static final MemorySegment NULL = MemorySegment.ofAddress(0L);
-    private static final SecureRandom secureRandom;
-    static {
-        // TODO: Verify using cryptographic random number generator properly
-        try {
-            secureRandom = SecureRandom.getInstanceStrong();
-        } catch (NoSuchAlgorithmException e) {
-            // This should never happen. The Javadoc for getInstanceStrong() says
-            // "Every implementation of the Java platform is required to support
-            // at least one strong SecureRandom implementation."
-            throw new RuntimeException("No strong SecureRandom available", e);
-        }
-    }
+    private final SecureRandom secureRandom;
 
     /// TBD: Static verify method that doesn't require a class instance.
     public static boolean ecdsaVerify(MemorySegment sig, MemorySegment msg_hash, MemorySegment pubkey) {
@@ -106,6 +95,26 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     public Secp256k1Foreign(int flags, boolean randomize) {
+        // TODO: Verify using cryptographic random number generator properly
+        // We initialize a new `SecureRandom` per instance for the following reasons:
+        // 1. Per-instance allocation avoids the static being contained in GraalVM
+        //    native-image instances (GraalVM may special-case this) or being cloned when the
+        //    containing process is cloned (may occur with containers, etc.)
+        // 2. On certain JDK/OS configurations it's possible `SecureRandom.getInstanceStrong()`
+        //    can cause a delay. It's better to incur this
+        // 3. Some implementations of `SecureRandom` may have locking contention
+        //    that could show up in a multi-threaded environment
+        // 4. Per-instance allocation allows for override for testing or custom
+        //    configurations, though this will require adding new constructors.
+        try {
+            secureRandom = SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            // This should never happen. The Javadoc for getInstanceStrong() says
+            // "Every implementation of the Java platform is required to support
+            // at least one strong SecureRandom implementation."
+            throw new RuntimeException("No strong SecureRandom available", e);
+        }
+
         /* Before we can call actual API functions, we need to create a "context". */
         ctx = secp256k1_h.secp256k1_context_create(flags);
 
@@ -545,7 +554,7 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     /// @param allocator allocator to create segment with
     /// @param size size in bytes of random data
     /// @return A newly-allocated memory segment full of random data
-    private static MemorySegment fill_random(SegmentAllocator allocator, int size) {
+    private MemorySegment fill_random(SegmentAllocator allocator, int size) {
         byte[] data = new byte[size];
         secureRandom.nextBytes(data);
         return allocator.allocateFrom(JAVA_BYTE, data);


### PR DESCRIPTION
There are a variety of reasons for this (see the comments in the code)