### PR TITLE
pom.xml: remove maven-surefire-plugin configuration from root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,10 +181,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
-                    <configuration>
-                        <argLine>@{argLine} -Djava.library.path=${env.LIBSECP_DIR}</argLine>
-                        <argLine>--enable-native-access=ALL-UNNAMED</argLine>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This is provided/overridden by the submodules and not needed here.