### PR TITLE
Cleanup Bouncy256k1

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -296,11 +296,6 @@ public class Bouncy256k1 implements Secp256k1 {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * This is preliminary implementation which is not yet optimized or constant time.
-     */
     @Override
     public SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpPrivKey privKey) {
         checkArg(msg_hash.length == 32, "Message must be 32-byte (hash)");
@@ -313,11 +308,6 @@ public class Bouncy256k1 implements Secp256k1 {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * This is preliminary implementation which is not yet optimized or constant time.
-     */
     @Override
     public SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpPrivKey privKey, byte[] auxiliaryRandom) {
         ECPrivateKeyParameters priv = new ECPrivateKeyParameters(privKey.getS(), BC_ECDOMAIN_PARAMS);
@@ -330,11 +320,6 @@ public class Bouncy256k1 implements Secp256k1 {
         return new SchnorrSignatureImpl(signer.generateSignature());
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * This is a preliminary implementation which is not yet optimized.
-     */
     @Override
     public SecpResult<Boolean> schnorrSigVerify(SchnorrSignature signature, byte[] msg_hash, SecpXOnlyPubKey pubKey) {
         ECPublicKeyParameters pub = new ECPublicKeyParameters(BC_CURVE.decodePoint(pubKey.serializeCompressed()), BC_ECDOMAIN_PARAMS);

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -231,8 +231,7 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     private static boolean hasLowR(BigInteger r) {
-        // TODO: check low-r directly on BigInteger
-        return SecpScalarImpl.integerTo32Bytes(r)[0] >= 0;
+        return !r.testBit(255);
     }
 
     // Convert and canonicalize signature

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -52,7 +52,6 @@ import org.bouncycastle.util.Arrays;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -76,10 +75,6 @@ public class Bouncy256k1 implements Secp256k1 {
     static final BigInteger HALF_CURVE_ORDER;
 
     private final SecureRandom secureRandom;
-
-    private static final byte[] TAG_AUX = "BIP0340/aux".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] TAG_NONCE = "BIP0340/nonce".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] TAG_CHALLENGE = "BIP0340/challenge".getBytes(StandardCharsets.UTF_8);
 
     static {
         // Tell Bouncy Castle to precompute data that's needed during secp256k1 calculations.


### PR DESCRIPTION
This PR makes the following three changes (as specified in #500):
- hasLowR() -- check for low-R directly on BigInteger.
- Remove unused TAG_AUX and related private constants.
- Remove "This is preliminary implementation which is not yet optimized or constant time." Javadoc comments (now that we are using the Bouncy Castle BIP-340 implementation).

Closes #500 