### PR TITLE
SecpECPoint: simplify, reduce usage

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
@@ -16,7 +16,6 @@
 package org.bitcoinj.secp;
 
 import org.bitcoinj.secp.internal.SecpECPoint;
-import org.bitcoinj.secp.internal.SecpPointUncompressed;
 
 import java.security.spec.ECPoint;
 
@@ -34,31 +33,6 @@ import java.security.spec.ECPoint;
 public interface SecpPoint {
     /** The P256K1 infinity point */
     Infinity POINT_INFINITY = Infinity.INSTANCE;
-
-    /**
-     * Construct an uncompressed SecpPoint from two field elements
-     * @param x x component
-     * @param y y component
-     * @return point
-     */
-    @Deprecated(forRemoval = true)
-    static SecpPointUncompressed of(SecpFieldElement x, SecpFieldElement y) {
-        return new SecpPointUncompressed(x, y);
-    }
-
-    /**
-     * Construct a SecpPoint from a Java Cryptography {@link ECPoint}
-     * @param point Java point
-     * @return SecpPoint point
-     */
-    @Deprecated(forRemoval = true)
-    static SecpPoint of(ECPoint point) {
-        return  point == ECPoint.POINT_INFINITY
-                    ? SecpPoint.POINT_INFINITY
-                    : point instanceof SecpECPoint
-                        ? (SecpECPoint) point
-                        : SecpPointUncompressed.of(point);
-    }
 
     /** Singleton representing the point-at-infinity */
     enum Infinity implements SecpPoint {

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpECPoint.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpECPoint.java
@@ -29,19 +29,20 @@ import java.security.spec.ECPoint;
 public class SecpECPoint extends ECPoint implements SecpPoint.Uncompressed {
     /**
      * Creates an ECPoint from the specified affine x-coordinate
-     * {@code x} and affine y-coordinate {@code y}.
+     * {@code x} and affine y-coordinate {@code y}. Constructor is private,
+     * and {@link SecpECPoint#of(Uncompressed)} only allows validated points.
      *
      * @param x the affine x-coordinate.
      * @param y the affine y-coordinate.
      * @throws NullPointerException if {@code x} or
      *                              {@code y} is null.
      */
-    public SecpECPoint(BigInteger x, BigInteger y) {
-        super(SecpFieldElement.checkInRange(x), SecpFieldElement.checkInRange(y));
+    private SecpECPoint(BigInteger x, BigInteger y) {
+        super(x, y);
     }
 
-    public SecpECPoint(SecpFieldElement x, SecpFieldElement y) {
-        super(x.toBigInteger(), y.toBigInteger());
+    public static SecpECPoint of(SecpPoint.Uncompressed point) {
+        return new SecpECPoint(point.x().toBigInteger(), point.y().toBigInteger());
     }
 
     @Override

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPointUncompressed.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPointUncompressed.java
@@ -20,7 +20,6 @@ import org.bitcoinj.secp.SecpPoint;
 import org.jspecify.annotations.Nullable;
 
 import java.math.BigInteger;
-import java.security.spec.ECPoint;
 import java.util.Objects;
 
 /**
@@ -33,11 +32,6 @@ public class SecpPointUncompressed implements SecpPoint.Uncompressed {
     public SecpPointUncompressed(SecpFieldElement x, SecpFieldElement y) {
         this.x = x;
         this.y = y;
-    }
-
-    public static SecpPointUncompressed of(ECPoint point) {
-        return new SecpPointUncompressed(SecpFieldElement.of(point.getAffineX()),
-                SecpFieldElement.of(point.getAffineY()));
     }
 
     public static SecpPointUncompressed of(BigInteger x, BigInteger y) {

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
@@ -52,7 +52,7 @@ public class SecpPubKeyImpl implements SecpPubKey {
 
     @Override
     public SecpECPoint getW() {
-        return new SecpECPoint(point.x(), point.y());
+        return SecpECPoint.of(point);
     }
 
     @Override

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
@@ -19,8 +19,6 @@ import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpPoint;
 import org.bitcoinj.secp.SecpPubKey;
 
-import java.security.spec.ECPoint;
-
 /**
  * Default/Internal SecpPubKey implementation storing as {@link SecpPointUncompressed}.
  */
@@ -35,19 +33,6 @@ public class SecpPubKeyImpl implements SecpPubKey {
         this.point = (point instanceof SecpPointUncompressed)
                 ? (SecpPointUncompressed) point
                 : new SecpPointUncompressed(point.x(), point.y());
-    }
-
-    public SecpPubKeyImpl(ECPoint ecPoint) {
-        this.point = SecpPointUncompressed.of(ecPoint);
-    }
-
-    /**
-     * Construct a public key from an {@link ECPoint}
-     * @param ecPoint the point
-     * @return the pubkey
-     */
-    public static SecpPubKey ofPoint(ECPoint ecPoint) {
-        return new SecpPubKeyImpl(ecPoint);
     }
 
     @Override

--- a/secp-api/src/test/java/org/bitcoinj/secp/P256K1PointTest.java
+++ b/secp-api/src/test/java/org/bitcoinj/secp/P256K1PointTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 
+import static org.bitcoinj.secp.Secp256k1.G;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -29,27 +30,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 public class P256K1PointTest {
     static BigInteger p = Secp256k1.P;
-    static SecpFieldElement ONE = SecpFieldElement.of(BigInteger.ONE);
-    static SecpFieldElement MAX = SecpFieldElement.of(p.subtract(BigInteger.ONE));
-    static BigInteger INT_MAX = MAX.toBigInteger();
 
     @Test
     void testDefaultImpl() {
-        SecpPoint.Uncompressed uncompressed = new SecpPointUncompressed(ONE, MAX);
-        assertEquals(ONE, uncompressed.x());
-        assertEquals(MAX, uncompressed.y());
+        SecpPoint.Uncompressed uncompressed = new SecpPointUncompressed(G.x(), G.y());
+        assertEquals(G.x(), uncompressed.x());
+        assertEquals(G.y(), uncompressed.y());
 
         SecpPoint.Compressed compressed = uncompressed.compress();
-        assertEquals(ONE, compressed.x());
+        assertEquals(G.x(), compressed.x());
         assertFalse(compressed.isOdd());
     }
 
     @Test
     void testECPointSubclass() {
-        SecpECPoint p = new SecpECPoint(ONE, MAX);
-        assertEquals(ONE, p.x());
-        assertEquals(MAX, p.y());
-        assertEquals(BigInteger.ONE, p.getAffineX());
-        assertEquals(INT_MAX, p.getAffineY());
+        SecpECPoint p = SecpECPoint.of(G);
+        assertEquals(G.x(), p.x());
+        assertEquals(G.y(), p.y());
+        assertEquals(G.x().toBigInteger(), p.getAffineX());
+        assertEquals(G.y().toBigInteger(), p.getAffineY());
     }
 }


### PR DESCRIPTION
Remove unused constructors to make it harder to create unvalidated points or pubKeys.

See the individual commits for details.
