### PR TITLE
Secp256k1: add constants for algorithm and format names. Use them.

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -20,6 +20,7 @@ import org.bitcoinj.secp.internal.SecpPointUncompressed;
 import java.io.Closeable;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECFieldFp;
 import java.security.spec.ECParameterSpec;
@@ -52,6 +53,9 @@ import java.util.stream.StreamSupport;
  * </ul>
  */
 public interface Secp256k1 extends Closeable {
+    /** The algorithm name returned by {@link ECPublicKey#getAlgorithm()} and {@link ECPrivateKey#getAlgorithm()} */
+    String ALGORITHM_NAME = "Secp256k1";
+
     /**
      * The prime {@code P}, that defines the secp256k1 field.
      * <p>

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPrivKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPrivKey.java
@@ -25,7 +25,8 @@ import java.security.spec.ECParameterSpec;
  * A P256k1 private key.
  */
 public interface SecpPrivKey extends ECPrivateKey {
-
+    /** The format name returned by {@link ECPrivateKey#getFormat()} */
+    String FORMAT_NAME = "Big-endian";
 
     @Override
     default String getAlgorithm() {
@@ -34,7 +35,7 @@ public interface SecpPrivKey extends ECPrivateKey {
 
     @Override
     default String getFormat() {
-        return "Big-endian";
+        return FORMAT_NAME;
     }
 
     /**

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPrivKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPrivKey.java
@@ -29,7 +29,7 @@ public interface SecpPrivKey extends ECPrivateKey {
 
     @Override
     default String getAlgorithm() {
-        return "Secp256k1";
+        return Secp256k1.ALGORITHM_NAME;
     }
 
     @Override

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
@@ -32,7 +32,7 @@ public interface SecpPubKey extends ECPublicKey, SecpPoint.Uncompressed {
      */
     @Override
     default String getAlgorithm() {
-        return "Secp256k1";
+        return Secp256k1.ALGORITHM_NAME;
     }
 
     /**

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
@@ -26,6 +26,11 @@ import java.security.spec.ECPoint;
  * A valid secp256k1 Public Key that is a subclass of {@link ECPublicKey}.
  */
 public interface SecpPubKey extends ECPublicKey, SecpPoint.Uncompressed {
+    /** The format name returned by {@link ECPublicKey#getFormat()} for compressed keys (the default) */
+    String COMPRESSED_FORMAT_NAME = "Compressed SEC";
+    /** The format name returned by {@link ECPublicKey#getFormat()} for uncompressed keys (typically non-HD {@code P2PKH} keys) */
+    String UNCOMPRESSED_FORMAT_NAME = "Uncompressed SEC";
+
     /**
      * Return associated cryptographic algorithm. This implements the {@link java.security.Key} interface.
      * @return string indicating algorithm
@@ -35,14 +40,6 @@ public interface SecpPubKey extends ECPublicKey, SecpPoint.Uncompressed {
         return Secp256k1.ALGORITHM_NAME;
     }
 
-    /**
-     * Return default encoding (serialization) format. This implements the {@link java.security.Key} interface.
-     * @return string indicating format
-     */
-    @Override
-    default String getFormat() {
-        return "Compressed SEC";
-    }
 
     /**
      * Return serialized key. This implements the {@link java.security.Key} interface and is an alias for {@link #serialize()}.

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
@@ -15,6 +15,7 @@
  */
 package org.bitcoinj.secp.internal;
 
+import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpPoint;
 import org.bitcoinj.secp.SecpPubKey;
@@ -33,6 +34,16 @@ public class SecpPubKeyImpl implements SecpPubKey {
         this.point = (point instanceof SecpPointUncompressed)
                 ? (SecpPointUncompressed) point
                 : new SecpPointUncompressed(point.x(), point.y());
+    }
+
+    // TODO: Add support for uncompressed format (for P2PKH non-HD keys)
+    /**
+     * Return default encoding (serialization) format. This implements the {@link java.security.Key} interface.
+     * @return string indicating format
+     */
+    @Override
+    public String getFormat() {
+        return COMPRESSED_FORMAT_NAME;
     }
 
     @Override


### PR DESCRIPTION
This is a temporary solution for alpha releases. For the longer-term issue, see:

* Issue #520 