### PR TITLE
Bouncy256k1: Return EcdsaSignatureBc from ECDSA signing methods

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
@@ -17,6 +17,8 @@ package org.bitcoinj.secp;
 
 import org.bitcoinj.secp.internal.EcdsaSignatureImpl;
 
+import java.math.BigInteger;
+
 /**
  * An secp256k1 ECDSA signature.
  */
@@ -32,6 +34,18 @@ public interface EcdsaSignature {
      * @return S
      */
     SecpScalar s();
+
+    /**
+     * Get scalar R
+     * @return R
+     */
+    BigInteger rBigInteger();
+
+    /**
+     * Get scalar S
+     * @return S
+     */
+    BigInteger sBigInteger();
 
     /**
      * Serialize as a Bitcoin <i>compact signature</i>. A compact signature is  the two signature component

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
@@ -18,6 +18,7 @@ package org.bitcoinj.secp.internal;
 import org.bitcoinj.secp.EcdsaSignature;
 import org.bitcoinj.secp.SecpScalar;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 
 /**
@@ -57,6 +58,16 @@ public class EcdsaSignatureImpl implements EcdsaSignature {
     @Override
     public SecpScalarImpl s() {
         return s;
+    }
+
+    @Override
+    public BigInteger rBigInteger() {
+        return r.toBigInteger();
+    }
+
+    @Override
+    public BigInteger sBigInteger() {
+        return s.toBigInteger();
     }
 
     @Override

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
@@ -38,6 +38,11 @@ public class EcdsaSignatureImpl implements EcdsaSignature {
         this.s = new SecpScalarImpl(s.serialize());
     }
 
+    public EcdsaSignatureImpl(BigInteger r, BigInteger s) {
+        this.r = new SecpScalarImpl(r);
+        this.s = new SecpScalarImpl(s);
+    }
+
     /**
      * Construct from a 64-byte, big-endian compact serialized signature
      * @param signature Signature in compact serialized format.

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -285,7 +285,7 @@ public class Bouncy256k1 implements Secp256k1 {
         signer.init(false, params);
         boolean result;
         try {
-            result = signer.verifySignature(msg_hash_data, signature.r().toBigInteger(), signature.s().toBigInteger());
+            result = signer.verifySignature(msg_hash_data, signature.rBigInteger(), signature.sBigInteger());
         } catch (NullPointerException e) {
             // Bouncy Castle contains a bug that can cause NPEs given specially crafted signatures. Those signatures
             // are inherently invalid/attack sigs so we just fail them here rather than crash the thread.

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -250,10 +250,7 @@ public class Bouncy256k1 implements Secp256k1 {
 
     // Convert and canonicalize signature
     private EcdsaSignature ecdsaSignature(BigInteger[] components) {
-        return new EcdsaSignatureImpl(
-                new SecpScalarImpl(components[0]),
-                new SecpScalarImpl(canonicalize(components[1]))
-        );
+        return new EcdsaSignatureBc(components[0], canonicalize(components[1]));
     }
 
     BigInteger canonicalize(BigInteger s) {

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/EcdsaSignatureBc.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/EcdsaSignatureBc.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.bouncy;
+
+import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.SecpScalar;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
+import org.bitcoinj.secp.internal.UInt256;
+
+import java.math.BigInteger;
+
+/**
+ * BigInteger-based ECDSA Signature implementation for Bouncy Castle.
+ */
+public class EcdsaSignatureBc implements EcdsaSignature {
+    private final BigInteger r, s;
+
+    public EcdsaSignatureBc(BigInteger r, BigInteger s) {
+        this.r = r;
+        this.s = s;
+    }
+
+    @Override
+    public SecpScalar r() {
+        return new SecpScalarImpl(r);
+    }
+
+    @Override
+    public SecpScalar s() {
+        return new SecpScalarImpl(s);
+    }
+
+    @Override
+    public BigInteger rBigInteger() {
+        return r;
+    }
+
+    @Override
+    public BigInteger sBigInteger() {
+        return s;
+    }
+
+    @Override
+    public byte[] serializeCompact() {
+        byte[] signature = new byte[64];
+        System.arraycopy(UInt256.integerTo32Bytes(r), 0, signature, 0, 32);
+        System.arraycopy(UInt256.integerTo32Bytes(s), 0, signature, 32, 32);
+        return signature;
+    }
+
+    @Override
+    public boolean hasLowR() {
+        return !r.testBit(255);
+    }
+}


### PR DESCRIPTION
This should speed up the proof-of-concept bitcoinj implementation that I have running (at least a little.)