### PR TITLE
Implement SecpPoint serialization in subclasses

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
@@ -83,16 +83,7 @@ public interface SecpPoint {
          */
         @Override
         default byte[] serialize() {
-            byte[] compressed = new byte[33];
-            compressed[0] = isOdd()
-                    ? (byte) 0x03      // odd
-                    : (byte) 0x02;     // even;
-            System.arraycopy(x().serialize(),
-                    0,
-                    compressed,
-                    1,
-                    32);
-            return compressed;
+            return serializeCompressed(x().serialize(), isOdd());
         }
     }
 
@@ -117,11 +108,7 @@ public interface SecpPoint {
          */
         @Override
         default byte[] serialize() {
-            byte[] uncompressed = new byte[65];
-            uncompressed[0] = 0x04;
-            System.arraycopy(x().serialize(), 0, uncompressed, 1, 32);
-            System.arraycopy(y().serialize(), 0, uncompressed, 33, 32);
-            return uncompressed;
+            return SecpPoint.serializeUncompressed(x().serialize(), y().serialize());
         }
 
         default ECPoint toECPoint() {
@@ -129,5 +116,41 @@ public interface SecpPoint {
                     ? (SecpECPoint) this
                     : new ECPoint(x().toBigInteger(), y().toBigInteger());
         }
+    }
+
+    /**
+     * Serialize a point to SEC Compressed format
+     * @param x x coordinate in 32-byte big-endian format
+     * @param isOdd low-bit of y coordinate
+     * @return serialized bytes
+     */
+    static byte[] serializeCompressed(byte[] x, boolean isOdd) {
+        byte[] compressed = new byte[33];
+        compressed[0] = serializationPrefix(isOdd);
+        System.arraycopy(x, 0, compressed, 1, 32);
+        return compressed;
+    }
+
+    /**
+     * Serialize a point to SEC Uncompressed format
+     * @param x x coordinate in 32-byte big-endian format
+     * @param y y coordinate in 32-byte big-endian format
+     * @return serialized bytes
+     */
+    static byte[] serializeUncompressed(byte[] x, byte[] y) {
+        byte[] uncompressed = new byte[65];
+        uncompressed[0] = 0x04;
+        System.arraycopy(x, 0, uncompressed, 1, 32);
+        System.arraycopy(y, 0, uncompressed, 33, 32);
+        return uncompressed;
+    }
+
+    /**
+     * Return SEC serialization prefix
+     * @param isOdd true if the y-coordinate is odd
+     * @return {@code 2} for even, {@code 3} for odd
+     */
+    static byte serializationPrefix(boolean isOdd) {
+        return isOdd ? (byte) 0x03 : (byte) 0x02;
     }
 }

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPoint.java
@@ -61,7 +61,7 @@ public interface SecpPoint {
         boolean isOdd();
 
         /**
-         * Serialize using the default format
+         * Serialize using the implementation's default format
          * @return serialized point
          */
         byte[] serialize();
@@ -76,15 +76,6 @@ public interface SecpPoint {
          * @return uncompressed point
          */
         Uncompressed uncompress();
-
-        /**
-         * Get the default serialization encoding
-         * @return serialized point
-         */
-        @Override
-        default byte[] serialize() {
-            return serializeCompressed(x().serialize(), isOdd());
-        }
     }
 
     /**
@@ -103,13 +94,21 @@ public interface SecpPoint {
         Compressed compress();
 
         /**
-         * Get the default serialization encoding
+         * Get the default serialization encoding. Uncompressed points default to uncompressed serialization,
+         * but his can be overridden by calling {@link #serialize(boolean)}.
          * @return serialized point
          */
         @Override
         default byte[] serialize() {
-            return SecpPoint.serializeUncompressed(x().serialize(), y().serialize());
+            return serialize(false);
         }
+
+        /**
+         * Return encoded key in either compressed or uncompressed SEC format.
+         * @param compressed Use compressed variant of format
+         * @return public key in SEC format
+         */
+        byte[] serialize(boolean compressed);
 
         default ECPoint toECPoint() {
             return this instanceof SecpECPoint

--- a/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/SecpPubKey.java
@@ -51,22 +51,13 @@ public interface SecpPubKey extends ECPublicKey, SecpPoint.Uncompressed {
     }
 
     /**
-     * Serialize key in primary encoded format (compressed)
+     * Serialize key in primary encoded format (compressed). Although this public key interface
+     * subclasses {@link SecpPoint.Uncompressed}, its _serialization_ defaults to compressed.
      * @return public key in compressed format
      */
+    @Override
     default byte[] serialize() {
         return serialize(true);
-    }
-
-    /**
-     * Return encoded key in either compressed or uncompressed SEC format.
-     * @param compressed Use compressed variant of format
-     * @return public key in SEC format
-     */
-    default byte[] serialize(boolean compressed) {
-        return compressed
-                ? point().compress().serialize()
-                : point().serialize();
     }
 
     /**

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpECPoint.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpECPoint.java
@@ -61,6 +61,13 @@ public class SecpECPoint extends ECPoint implements SecpPoint.Uncompressed {
     }
 
     @Override
+    public byte[] serialize(boolean compressed) {
+        return compressed
+                ? SecpPoint.serializeUncompressed(UInt256.integerTo32Bytes(getAffineX()), UInt256.integerTo32Bytes(getAffineY()))
+                : SecpPoint.serializeCompressed(UInt256.integerTo32Bytes(getAffineX()), isOdd());
+    }
+
+    @Override
     public boolean isOdd() {
         return getAffineY().testBit(0);
     }

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPointCompressed.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPointCompressed.java
@@ -29,7 +29,7 @@ class SecpPointCompressed implements SecpPoint.Compressed {
     private final SecpFieldElement x;
     private final boolean isOdd;
 
-    SecpPointCompressed(SecpFieldElement x, SecpFieldElement y) {
+    public SecpPointCompressed(SecpFieldElement x, SecpFieldElement y) {
         this.x = x;
         this.isOdd = y.isOdd();
     }
@@ -47,6 +47,15 @@ class SecpPointCompressed implements SecpPoint.Compressed {
     @Override
     public Uncompressed uncompress() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Get the default serialization encoding
+     * @return serialized point
+     */
+    @Override
+    public byte[] serialize() {
+        return SecpPoint.serializeCompressed(x().serialize(), isOdd());
     }
 
     @Override

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPointUncompressed.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPointUncompressed.java
@@ -59,6 +59,13 @@ public class SecpPointUncompressed implements SecpPoint.Uncompressed {
         return new SecpPointCompressed(x, y);
     }
 
+    @Override
+    public byte[] serialize(boolean compressed) {
+        return compressed
+                ? SecpPoint.serializeCompressed(x().serialize(), isOdd())
+                : SecpPoint.serializeUncompressed(x().serialize(), y().serialize());
+    }
+
     public boolean equals(@Nullable SecpPoint other) {
         if (!(other instanceof SecpPointUncompressed)) return false;
         Uncompressed otherUncompressed = (Uncompressed) other;

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpPubKeyImpl.java
@@ -57,6 +57,11 @@ public class SecpPubKeyImpl implements SecpPubKey {
     }
 
     @Override
+    public byte[] serialize(boolean compressed) {
+        return point.serialize(compressed);
+    }
+
+    @Override
     public String toString() {
         return ByteUtils.toHexString(point.compress().serialize());
     }

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpXOnlyPubKeyImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/SecpXOnlyPubKeyImpl.java
@@ -16,6 +16,7 @@
 package org.bitcoinj.secp.internal;
 
 import org.bitcoinj.secp.SecpFieldElement;
+import org.bitcoinj.secp.SecpPoint;
 import org.bitcoinj.secp.SecpXOnlyPubKey;
 import org.jspecify.annotations.Nullable;
 
@@ -44,10 +45,7 @@ public class SecpXOnlyPubKeyImpl implements SecpXOnlyPubKey, ByteArray {
      * @return SECG Compressed (even) value (33-bytes)
      */
     public static byte[] xOnlyToSerializedCompressed(byte[] xOnly) {
-        byte[] compressed = new byte[33];
-        compressed[0] = 0x02;   // Even 'y'
-        System.arraycopy(xOnly, 0, compressed, 1, 32);
-        return compressed;
+        return SecpPoint.serializeCompressed(xOnly, false);
     }
 
     @Override


### PR DESCRIPTION
 2 commits:

1. extract SEC serialization to static methods
2. clean-up and better document serialization

First we extract he serialization primitives to static methods so they can be freely reused by implementations.

In the second commit we refactor serialization to enable implementations to choose their default serialization and to efficiently implement serialization from their internal formats.

The new behavior is:

**INTERFACES**

* `SecpPoint.Compressed`: can only serialize in compressed format. Must be
  decompressed for other options.

* `SecpPoint.Uncompressed`: defaults to uncompressed format. Declares
  `serialize(boolean)` so implementations must provide serialization
   to both formats.

* `SepPubKey`: defaults to compressed format. Because it is a subclass of
  Uncompressed, `serialize(boolean)` can be used to serialize uncompressed.

**IMPLEMENTATIONS**

Since the implementations are aware of the format their x and y are
stored in, they must implement the actual serialization as they
can do it most efficiently.

Implementations of `Compressed` must implement `serialize()`,
and implementations of `Uncompressed` must implement `serialize(boolean)`.

* `SecECPoint`: serializes from internal BigInteger implementation (x, y)

* `SecpPointCompressed`: serializes from SecpFieldElement (x, isOdd)

* `SecpPointUncompressed`: serializes from SecpFieldElement (x, y)

* `SecpPubKeyImpl`: delegates to its SecpPointUncompressed (x, y)

