### PR TITLE
GHA build.yml: use env var LIBSECP_DIR on macOS runners.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           brew install secp256k1
           echo "DYLD_LIBRARY_PATH=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
-          echo "JAVA_TOOL_OPTIONS=-Djava.library.path=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
+          echo "LIBSECP_DIR=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
       - name: Build with Maven
         run: mvn verify -Prun-schnorr,run-ecdsa,run-schnorr-kotlin,run-ecdsa-kotlin
       - name: Compute CI revision
@@ -76,7 +76,7 @@ jobs:
         run: |
           brew install secp256k1
           echo "DYLD_LIBRARY_PATH=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
-          echo "JAVA_TOOL_OPTIONS=-Djava.library.path=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
+          echo "LIBSECP_DIR=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
       - name: Build (JIT) with Maven
         run: mvn verify -Prun-schnorr,run-ecdsa,run-schnorr-kotlin,run-ecdsa-kotlin
       - name: Run Native Integration Tests


### PR DESCRIPTION
Linux GitHub Actions runners are setting LIBSECP_DIR to tell Maven how to find libsecp256k1, as documented in the README.

On macOS, we were setting JAVA_TOOL_OPTIONS which works but is:

1. more invasive (it affects other Java tools, not just our Maven pom)
2. does not test the mechanism documented in the README

This commit sets the `LIBSECP_DIR` on macOS for the `build_maven` and `build_graalvm_maven` jobs -- the same as for Linux.