### PR TITLE
Consistent ECDSA verification with high-s signatures.

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/EcdsaSignature.java
@@ -55,11 +55,26 @@ public interface EcdsaSignature {
     byte[] serializeCompact();
 
     /**
-     * Is this signature a "low R" signature.
+     * Indicates this signature has a "low-r" value.
      * In other words: In a 256-bit big-endian representation of {@code R}, the high-bit is zero.
-     * @return true if this signature has a <i>low R</i> value.
+     * @return true if this signature has a low-<i>r</i> value.
      */
     boolean hasLowR();
+
+    /**
+     * Indicates this signature has a "low-s" value.
+     * In other words: if s is less than or equal to the half curve order.
+     * @return true if this signature has a low-<i>s</i> value.
+     */
+    boolean hasLowS();
+
+    /**
+     * Normalize this signature to its low-<i>s</i> form.
+     * If {@link #hasLowS()} is already true, this signature is returned unchanged. Otherwise, an equivalent
+     * signature is returned with <i>s</i> replaced by {@link Secp256k1#N} - <i>s</i>.
+     * @return a signature with a low-<i>s</i> value
+     */
+    EcdsaSignature normalize();
 
     /**
      * Create an ECDSA signature from serialized bytes

--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -278,7 +278,7 @@ public interface Secp256k1 extends Closeable {
     SecpResult<EcdsaSignature> ecdsaSignatureParseCompact(byte[] serialized_signature);
 
     /**
-     * Verify an ECDSA signature.
+     * Verify an ECDSA signature is valid and low-s.
      * @param sig The signature to verify.
      * @param msg_hash_data A 32-byte hash of the message to verify.
      * @param pubKey The pubkey that must have signed the message

--- a/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/internal/EcdsaSignatureImpl.java
@@ -16,6 +16,7 @@
 package org.bitcoinj.secp.internal;
 
 import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.SecpScalar;
 
 import java.math.BigInteger;
@@ -79,6 +80,16 @@ public class EcdsaSignatureImpl implements EcdsaSignature {
     public boolean hasLowR() {
         // Is the high-bit of the first (high, big-endian) byte zero?
         return this.r().serialize()[0] >= 0;
+    }
+
+    @Override
+    public boolean hasLowS() {
+        return this.sBigInteger().compareTo(Secp256k1.HALF_CURVE_ORDER.toBigInteger()) <= 0;
+    }
+
+    @Override
+    public EcdsaSignature normalize() {
+        return hasLowS() ? this : new EcdsaSignatureImpl(rBigInteger(), Secp256k1.N.subtract(sBigInteger()));
     }
 
     @Override

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -282,6 +282,7 @@ public class Bouncy256k1 implements Secp256k1 {
     @Override
     public SecpResult<Boolean> ecdsaVerify(EcdsaSignature signature, byte[] msg_hash_data, SecpPubKey pubKey) {
         checkArg(msg_hash_data.length == 32, "Message must be 32-byte (hash)");
+        if (!signature.hasLowS()) return SecpResult.ok(false);
         ECDSASigner signer = new ECDSASigner();
         ECPoint pubPoint = BC.fromSecpPoint(pubKey.point());
         ECPublicKeyParameters params = new ECPublicKeyParameters(pubPoint, BC_ECDOMAIN_PARAMS);

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/EcdsaSignatureBc.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/EcdsaSignatureBc.java
@@ -68,6 +68,16 @@ public class EcdsaSignatureBc implements EcdsaSignature {
     }
 
     @Override
+    public boolean hasLowS() {
+        return s.compareTo(Bouncy256k1.HALF_CURVE_ORDER) <= 0;
+    }
+
+    @Override
+    public EcdsaSignature normalize() {
+        return hasLowS() ? this : new EcdsaSignatureBc(rBigInteger(), Bouncy256k1.N.subtract(sBigInteger()));
+    }
+
+    @Override
     public String toString() {
         return "EcdsaSignatureBc [r=" + UInt256.toString(r) + ", s=" + UInt256.toString(s) + "]";
     }

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
@@ -31,21 +31,30 @@ import java.math.BigInteger;
 import static org.bitcoinj.secp.integration.SecpTestSupport.hash;
 import static org.bitcoinj.secp.integration.SecpTestSupport.parseHex;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test ECDA Signing and verification.
  */
 public class EcdsaTest implements SecpTestSupport {
-    private static final byte[] msg_hash = hash("Hello, world!");
+    private static final byte[] MSG_HASH = hash("Hello, world!");
+
+    private static final byte[] TEST_PRIVKEY = hash("secp256k1-jdk ECDSA canonicalization test key");
+    /// This message was selected such that a high-s signature would be produced under TEST_PRIVKEY. Specifically, a
+    /// high-s signature would be produced by the `sign` algorithm defined by BIP-461 given the message and private key
+    /// (and `extra` = b''). Both FFM and BC implementations effectively implement `sign`, just with low-*s* normalization.
+    private static final byte[] HIGH_S_MSG_HASH = hash("high-s");
+    /// High-s signature generated from MSG_HASH (not HIGH_S_MSG_HASH) and TEST_PRIVKEY, but with a negated *s*.
+    private static final byte[] HIGH_S_SIG = parseHex("A2377BF9BFCC5A3E1E0E62EAC08F8F99B5FE37330AAA4CDADDA565C6FE2CF568D267903C02788014B75BA39F3BC534B67623AD2CBF64A578A593B9CB95535A74");
 
     @MethodSource("secpImplementations")
     @ParameterizedTest(name = "Test Ecdsa for {0}")
     void testEcdsa(Secp256k1 secp) {
         SecpPrivKey privKey = secp.ecPrivKeyCreate();
         SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
-        EcdsaSignature sig = secp.ecdsaSign(msg_hash, privKey).get();
-        boolean validSignature = secp.ecdsaVerify(sig, msg_hash, pubKey).get();
+        EcdsaSignature sig = secp.ecdsaSign(MSG_HASH, privKey).get();
+        boolean validSignature = secp.ecdsaVerify(sig, MSG_HASH, pubKey).get();
         assertTrue(validSignature);
     }
 
@@ -54,10 +63,43 @@ public class EcdsaTest implements SecpTestSupport {
     void testEcdsaLowR(Secp256k1 secp) {
         SecpPrivKey privKey = secp.ecPrivKeyCreate();
         SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
-        EcdsaSignature sig = secp.ecdsaSignLowR(msg_hash, privKey).get();
-        boolean validSignature = secp.ecdsaVerify(sig, msg_hash, pubKey).get();
+        EcdsaSignature sig = secp.ecdsaSignLowR(MSG_HASH, privKey).get();
+        boolean validSignature = secp.ecdsaVerify(sig, MSG_HASH, pubKey).get();
         assertTrue(validSignature);
         assertTrue(sig.hasLowR());
+    }
+
+    @MethodSource("secpImplementations")
+    @ParameterizedTest(name = "Test Ecdsa for {0}")
+    void testEcdsaCanonicalSign(Secp256k1 secp) {
+        SecpPrivKey privKey = secp.ecPrivKeyImport(TEST_PRIVKEY);
+        SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
+
+        EcdsaSignature sig = secp.ecdsaSign(HIGH_S_MSG_HASH, privKey).get();
+
+        boolean validSignature = secp.ecdsaVerify(sig, HIGH_S_MSG_HASH, pubKey).get();
+
+        assertTrue(validSignature);
+        assertTrue(sig.hasLowS());
+    }
+
+    @MethodSource("secpImplementations")
+    @ParameterizedTest(name = "Test Ecdsa for {0}")
+    void testEcdsaVerifyHighSFails(Secp256k1 secp) {
+        SecpPrivKey privKey = secp.ecPrivKeyImport(TEST_PRIVKEY);
+        SecpPubKey pubKey = secp.ecPubKeyCreate(privKey);
+
+        EcdsaSignature sigHighS = secp.ecdsaSignatureParseCompact(HIGH_S_SIG).get();
+        assertFalse(sigHighS.hasLowS());
+
+        boolean validSignature1 = secp.ecdsaVerify(sigHighS, MSG_HASH, pubKey).get();
+        assertFalse(validSignature1);
+
+        EcdsaSignature sigLowS = sigHighS.normalize();
+        assertTrue(sigLowS.hasLowS());
+
+        boolean validSignature2 = secp.ecdsaVerify(sigLowS, MSG_HASH, pubKey).get();
+        assertTrue(validSignature2);
     }
 
     @MethodSource("secpImplementations")
@@ -84,15 +126,15 @@ public class EcdsaTest implements SecpTestSupport {
 
             assertArrayEquals(pubKey1.serialize(), pubKey2.serialize());
 
-            EcdsaSignature sig1 = secp1.ecdsaSign(msg_hash, secKey1).get();
-            EcdsaSignature sig2 = secp2.ecdsaSign(msg_hash, secKey2).get();
+            EcdsaSignature sig1 = secp1.ecdsaSign(MSG_HASH, secKey1).get();
+            EcdsaSignature sig2 = secp2.ecdsaSign(MSG_HASH, secKey2).get();
 
             assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
 
-            assertTrue(secp1.ecdsaVerify(sig1, msg_hash, pubKey1).get());
-            assertTrue(secp1.ecdsaVerify(sig2, msg_hash, pubKey2).get());
-            assertTrue(secp2.ecdsaVerify(sig1, msg_hash, pubKey1).get());
-            assertTrue(secp2.ecdsaVerify(sig2, msg_hash, pubKey2).get());
+            assertTrue(secp1.ecdsaVerify(sig1, MSG_HASH, pubKey1).get());
+            assertTrue(secp1.ecdsaVerify(sig2, MSG_HASH, pubKey2).get());
+            assertTrue(secp2.ecdsaVerify(sig1, MSG_HASH, pubKey1).get());
+            assertTrue(secp2.ecdsaVerify(sig2, MSG_HASH, pubKey2).get());
         }
     }
 
@@ -108,15 +150,15 @@ public class EcdsaTest implements SecpTestSupport {
 
             assertArrayEquals(pubKey1.serialize(), pubKey2.serialize());
 
-            EcdsaSignature sig1 = secp1.ecdsaSignLowR(msg_hash, secKey1).get();
-            EcdsaSignature sig2 = secp2.ecdsaSignLowR(msg_hash, secKey2).get();
+            EcdsaSignature sig1 = secp1.ecdsaSignLowR(MSG_HASH, secKey1).get();
+            EcdsaSignature sig2 = secp2.ecdsaSignLowR(MSG_HASH, secKey2).get();
 
             assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
 
-            assertTrue(secp1.ecdsaVerify(sig1, msg_hash, pubKey1).get());
-            assertTrue(secp1.ecdsaVerify(sig2, msg_hash, pubKey2).get());
-            assertTrue(secp2.ecdsaVerify(sig1, msg_hash, pubKey1).get());
-            assertTrue(secp2.ecdsaVerify(sig2, msg_hash, pubKey2).get());
+            assertTrue(secp1.ecdsaVerify(sig1, MSG_HASH, pubKey1).get());
+            assertTrue(secp1.ecdsaVerify(sig2, MSG_HASH, pubKey2).get());
+            assertTrue(secp2.ecdsaVerify(sig1, MSG_HASH, pubKey1).get());
+            assertTrue(secp2.ecdsaVerify(sig2, MSG_HASH, pubKey2).get());
         }
     }
 


### PR DESCRIPTION
BC accepts high-s ECDSA signatures but FFM would reject them. This PR updates BC `ecdsaVerify` to reject high-s signatures, as well as adds tests and proper documentation.

Closes #518.