### PR TITLE
Secp256k1.Provider: id() is Optional<ProviderId>, name() is String

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -25,6 +25,7 @@ import java.security.spec.ECFieldFp;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.EllipticCurve;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -132,13 +133,15 @@ public interface Secp256k1 extends Closeable {
 
         @Override
         public String toString() {
-            return id();
+            return id;
         }
 
         /**
          * Get the provider ID as a string
          * @return provider ID string
+         * @deprecated Use {@link ProviderId#toString()}
          */
+        @Deprecated
         public String id() {
             return id;
         }
@@ -390,8 +393,20 @@ public interface Secp256k1 extends Closeable {
      * @return A Secp256k1 instance using the <i>default</i> implementation
      */
     static Secp256k1 get() {
-        return findAll(p -> p.id().equals(ProviderId.LIBSECP256K1_FFM.id())).findFirst()
+        return findAll(p -> p.id().isPresent() && p.id().get() == ProviderId.LIBSECP256K1_FFM)
+                .findFirst()
                 .orElseThrow(() -> new NoSuchElementException("Default Provider not found."))
+                .get();
+    }
+
+    /**
+     * Get implementation by name
+     * @param name implementation name
+     * @return A Secp256k1 instance using the <i>default</i> implementation
+     */
+    static Secp256k1 getByName(String name) {
+        return findAll(p -> p.name().equals(name)).findFirst()
+                .orElseThrow(() -> new NoSuchElementException("Provider name " + name + " not found."))
                 .get();
     }
 
@@ -400,19 +415,10 @@ public interface Secp256k1 extends Closeable {
      * @param id implementation ID
      * @return A Secp256k1 instance using the <i>default</i> implementation
      */
-    static Secp256k1 getById(String id) {
-        return findAll(provider -> provider.id().equals(id)).findFirst()
-                .orElseThrow(() -> new NoSuchElementException("Provider " + id + " not found."))
+    static Secp256k1 getById(ProviderId id) {
+        return findAll(p -> p.id().isPresent() && p.id().get() == id).findFirst()
+                .orElseThrow(() -> new NoSuchElementException("Provider ID " + id + " not found."))
                 .get();
-    }
-
-    /**
-     * Get implementation by ID enum
-     * @param idEnum implementation ID enum
-     * @return A Secp256k1 instance using the <i>default</i> implementation
-     */
-    static Secp256k1 getById(ProviderId idEnum) {
-        return getById(idEnum.id());
     }
 
     /**
@@ -423,7 +429,14 @@ public interface Secp256k1 extends Closeable {
          * Implementations must implement this method to return a unique ID
          * @return A unique ID for this Secp256k1 implementation
          */
-        String id();
+        Optional<ProviderId> id();
+
+        /**
+         * Implementations must implement this method to return a unique name. Experimental
+         * implementations should use domain-style names (e.g. {@code org.project.name})
+         * @return A unique ID for this Secp256k1 implementation
+         */
+        String name();
 
         /**
          * Get the instance this provider object describes

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/BouncyProvider.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/BouncyProvider.java
@@ -17,19 +17,22 @@ package org.bitcoinj.secp.bouncy;
 
 import org.bitcoinj.secp.Secp256k1;
 
+import java.util.Optional;
+
 import static org.bitcoinj.secp.Secp256k1.ProviderId.BOUNCY_CASTLE;
 
 /**
  * Provider implementations providing name and access to {@link Bouncy256k1}.
  */
 public class BouncyProvider implements Secp256k1.Provider {
-    /**
-     * Default constructor.
-     */
-    public BouncyProvider() {}
     @Override
-    public String id() {
-        return BOUNCY_CASTLE.id();
+    public Optional<Secp256k1.ProviderId> id() {
+        return Optional.of(BOUNCY_CASTLE);
+    }
+
+    @Override
+    public String name() {
+        return BOUNCY_CASTLE.toString();
     }
 
     @Override

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/ForeignProvider.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/ForeignProvider.java
@@ -17,12 +17,19 @@ package org.bitcoinj.secp.ffm;
 
 import org.bitcoinj.secp.Secp256k1;
 
+import java.util.Optional;
+
 import static org.bitcoinj.secp.Secp256k1.ProviderId.LIBSECP256K1_FFM;
 
 public class ForeignProvider implements Secp256k1.Provider {
     @Override
-    public String id() {
-        return LIBSECP256K1_FFM.id();
+    public Optional<Secp256k1.ProviderId> id() {
+        return Optional.of(LIBSECP256K1_FFM);
+    }
+
+    @Override
+    public String name() {
+        return LIBSECP256K1_FFM.toString();
     }
 
     @Override

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/Secp256K1ProviderTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/Secp256K1ProviderTest.java
@@ -19,6 +19,9 @@ import org.bitcoinj.secp.Secp256k1;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,7 +32,10 @@ public class Secp256K1ProviderTest implements SecpTestSupport {
     @MethodSource("secpProviders")
     @ParameterizedTest(name = "Provider: {0}")
     void checkProviders(Secp256k1.Provider provider) {
-        assertTrue(provider.id().length() > 1);
+        // All providers in this test must have an ID
+        Optional<Secp256k1.ProviderId> id = provider.id();
+        assertTrue(id.isPresent());
+        assertTrue(Arrays.asList(Secp256k1.ProviderId.values()).contains(id.get()));
     }
 
     @MethodSource("secpImplementations")


### PR DESCRIPTION
Refactor `Provider` to more clearly distinguish between ProviderId (enum) and name (String.) ProviderId is optional because implementations must be registered and added to the enum in order to have one. 3rd-party implementations will have a name only. In the future we could possibly add additional implementations to the enum.