### PR TITLE
Bouncy256k1, PubKeyTest: replace use of deprecated SecpPrivKey.of(), EcdsaTest: combine duplicate variables

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -140,7 +140,7 @@ public class Bouncy256k1 implements Secp256k1 {
         AsymmetricCipherKeyPair bcKeyPair = bcKeyPairCreate();
         BigInteger privKey = ((ECPrivateKeyParameters) bcKeyPair.getPrivate()).getD();
         ECPoint pubPoint = (((ECPublicKeyParameters) bcKeyPair.getPublic()).getQ());
-        return new SecpKeyPairImpl(SecpPrivKey.of(privKey), BC.toSecpPubKey(pubPoint));
+        return new SecpKeyPairImpl(new SecpPrivKeyBc(privKey), BC.toSecpPubKey(pubPoint));
     }
 
     @Override

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/EcdsaTest.java
@@ -118,16 +118,14 @@ public class EcdsaTest implements SecpTestSupport {
     @Test
     void ecdsaCrossCheck() {
         try (Secp256k1 secp1 = new Secp256k1Foreign(); Secp256k1 secp2 = new Bouncy256k1()) {
-            SecpPrivKey secKey1 = secp1.ecPrivKeyCreate();
-            SecpPubKey pubKey1 = secp1.ecPubKeyCreate(secKey1);
-
-            SecpPrivKey secKey2 = secKey1;
-            SecpPubKey pubKey2 = secp2.ecPubKeyCreate(secKey1);
+            SecpPrivKey secKey = secp1.ecPrivKeyCreate();
+            SecpPubKey pubKey1 = secp1.ecPubKeyCreate(secKey);
+            SecpPubKey pubKey2 = secp2.ecPubKeyCreate(secKey);
 
             assertArrayEquals(pubKey1.serialize(), pubKey2.serialize());
 
-            EcdsaSignature sig1 = secp1.ecdsaSign(MSG_HASH, secKey1).get();
-            EcdsaSignature sig2 = secp2.ecdsaSign(MSG_HASH, secKey2).get();
+            EcdsaSignature sig1 = secp1.ecdsaSign(MSG_HASH, secKey).get();
+            EcdsaSignature sig2 = secp2.ecdsaSign(MSG_HASH, secKey).get();
 
             assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
 
@@ -142,16 +140,14 @@ public class EcdsaTest implements SecpTestSupport {
     @Test
     void ecdsaCrossCheckLowR() {
         try (Secp256k1 secp1 = new Secp256k1Foreign(); Secp256k1 secp2 = new Bouncy256k1()) {
-            SecpPrivKey secKey1 = secp1.ecPrivKeyCreate();
-            SecpPubKey pubKey1 = secp1.ecPubKeyCreate(secKey1);
-
-            SecpPrivKey secKey2 = secKey1;
-            SecpPubKey pubKey2 = secp2.ecPubKeyCreate(secKey1);
+            SecpPrivKey secKey = secp1.ecPrivKeyCreate();
+            SecpPubKey pubKey1 = secp1.ecPubKeyCreate(secKey);
+            SecpPubKey pubKey2 = secp2.ecPubKeyCreate(secKey);
 
             assertArrayEquals(pubKey1.serialize(), pubKey2.serialize());
 
-            EcdsaSignature sig1 = secp1.ecdsaSignLowR(MSG_HASH, secKey1).get();
-            EcdsaSignature sig2 = secp2.ecdsaSignLowR(MSG_HASH, secKey2).get();
+            EcdsaSignature sig1 = secp1.ecdsaSignLowR(MSG_HASH, secKey).get();
+            EcdsaSignature sig2 = secp2.ecdsaSignLowR(MSG_HASH, secKey).get();
 
             assertArrayEquals(sig1.serializeCompact(), sig2.serializeCompact());
 

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/PubKeyTest.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/PubKeyTest.java
@@ -66,7 +66,7 @@ public class PubKeyTest implements SecpTestSupport {
     @MethodSource("secpImplementations")
     @ParameterizedTest(name = "Test Pubkeys for {0}")
     void pubKeySerialization(Secp256k1 secp) {
-        SecpPubKey pubKey = secp.ecPubKeyCreate(SecpPrivKey.of(BigInteger.ONE));
+        SecpPubKey pubKey = secp.ecPubKeyCreate(secp.ecPrivKeyImport(BigInteger.ONE));
         // Default serialization for public keys is compressed format
         assertArrayEquals(ONE_SERIALIZED_COMPRESSED, pubKey.serialize());
         assertArrayEquals(ONE_SERIALIZED_COMPRESSED, pubKey.serialize(true));


### PR DESCRIPTION
These 2 commits were previously in PR #524, but were extracted for ease-of-review.
