### PR TITLE
SecpPubKeyBc: Fix toString() method and BROKEN BUILD

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpPubKeyBc.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpPubKeyBc.java
@@ -18,9 +18,9 @@ package org.bitcoinj.secp.bouncy;
 import org.bitcoinj.secp.SecpFieldElement;
 import org.bitcoinj.secp.SecpPoint;
 import org.bitcoinj.secp.SecpPubKey;
-import org.bitcoinj.secp.internal.ByteUtils;
 import org.bitcoinj.secp.internal.SecpECPoint;
 import org.bitcoinj.secp.internal.SecpPointCompressed;
+import org.bitcoinj.secp.internal.UInt256;
 import org.bouncycastle.math.ec.custom.sec.SecP256K1Point;
 import org.jspecify.annotations.Nullable;
 
@@ -145,6 +145,6 @@ class SecpPubKeyBc implements SecpPubKey {
 
     @Override
     public String toString() {
-        return ByteUtils.toHexString(this.serialize());
+        return UInt256.toHexString(this.serialize());
     }
 }


### PR DESCRIPTION
The build was broken 2 commits back in 2e1a9207fc743518fd6ac59fe5e4e14d15a5dacd and for some reason the merge queue merged it anyway.

This commit fixes the issue: toHexString() was moved from UInt256  to ByteUtils.