### PR TITLE
GHA build.yml: add Java 26 to matrix for `build_maven`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-26.04, ubuntu-26.04-arm, macOS-15]
+        java: [ '25', '26' ]
         distribution: ['temurin']
       fail-fast: false
-    name: ${{ matrix.os }} JDK 25 (via Maven)
+    name: ${{ matrix.os }} JDK ${{ matrix.java }} (via Maven)
     steps:
       - name: Git checkout
         uses: actions/checkout@v6
@@ -18,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: ${{ matrix.distribution }}
-          java-version: 25
+          java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Install secp256k1 with APT
         if: runner.os == 'Linux'


### PR DESCRIPTION
We should do some testing with newer, non-LTS JDKs.

Apparently there is no JDK 26 for GraalVM CE. And  there is no JDK 26 in Nixpkgs yet. So we will only add '26' to the matrix for `build_maven`.