### PR TITLE
SecKeyPairBc: Bouncy Castle SecpKeyPair implementation

### DIFF
--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -27,8 +27,6 @@ import org.bitcoinj.secp.Secp256k1;
 import org.bitcoinj.secp.EcdsaSignature;
 import org.bitcoinj.secp.internal.EcdhSharedSecretImpl;
 import org.bitcoinj.secp.internal.SchnorrSignatureImpl;
-import org.bitcoinj.secp.internal.SecpKeyPairImpl;
-import org.bitcoinj.secp.internal.SecpPrivKeyImpl;
 import org.bitcoinj.secp.internal.SecpScalarImpl;
 import org.bitcoinj.secp.internal.SecpXOnlyPubKeyImpl;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -135,24 +133,24 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public SecpKeyPair ecKeyPairCreate() {
+    public SecpKeyPairBc ecKeyPairCreate() {
         AsymmetricCipherKeyPair bcKeyPair = bcKeyPairCreate();
         BigInteger privKey = ((ECPrivateKeyParameters) bcKeyPair.getPrivate()).getD();
-        ECPoint pubPoint = (((ECPublicKeyParameters) bcKeyPair.getPublic()).getQ());
-        return new SecpKeyPairImpl(new SecpPrivKeyBc(privKey), toSecpPubKey(pubPoint));
+        SecP256K1Point pubPoint = (SecP256K1Point) (((ECPublicKeyParameters) bcKeyPair.getPublic()).getQ());
+        return new SecpKeyPairBc(pubPoint, privKey);
     }
 
     @Override
     public SecpKeyPair ecKeyPairCreate(SecpPrivKey privKey) {
-        SecpPrivKeyBc priv = (privKey instanceof SecpPrivKeyBc)
-                ? (SecpPrivKeyBc) privKey
-                : new SecpPrivKeyBc(privKey.getS());
-        SecpPubKey pub = ecPubKeyCreate(priv);
-        return new SecpKeyPairImpl(priv, pub);
+        return ecKeyPairCreate(privKey.getS());
+    }
+
+    private SecpKeyPairBc ecKeyPairCreate(BigInteger privKey) {
+        return new SecpKeyPairBc(bcPubPointFromPrivKey(privKey), privKey);
     }
 
     /**
-     * Generate a Bouncy Castle secp256k1 {@link AsymmetricCipherKeyPair}.
+     * Generate a random Bouncy Castle secp256k1 {@link AsymmetricCipherKeyPair}.
      * @return key pair
      */
     private AsymmetricCipherKeyPair bcKeyPairCreate() {
@@ -160,6 +158,10 @@ public class Bouncy256k1 implements Secp256k1 {
         ECKeyGenerationParameters keygenParams = new ECKeyGenerationParameters(BC_ECDOMAIN_PARAMS, secureRandom);
         generator.init(keygenParams);
         return generator.generateKeyPair();
+    }
+
+    private static SecP256K1Point bcPubPointFromPrivKey(BigInteger privKey) {
+        return (SecP256K1Point) BC_ECDOMAIN_PARAMS.getG().multiply(privKey).normalize();
     }
 
     @Override

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -113,18 +113,18 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public SecpPrivKey ecPrivKeyCreate() {
+    public SecpPrivKeyBc ecPrivKeyCreate() {
         BigInteger privKey = ((ECPrivateKeyParameters) bcKeyPairCreate().getPrivate()).getD();
         return new SecpPrivKeyBc(privKey);
     }
 
     @Override
-    public SecpPrivKey ecPrivKeyImport(BigInteger privKeyInt) {
+    public SecpPrivKeyBc ecPrivKeyImport(BigInteger privKeyInt) {
         return SecpPrivKeyBc.of(privKeyInt);
     }
 
     @Override
-    public SecpPrivKey ecPrivKeyImport(byte[] privKeyBytes) {
+    public SecpPrivKeyBc ecPrivKeyImport(byte[] privKeyBytes) {
         return SecpPrivKeyBc.of(privKeyBytes);
     }
 
@@ -163,14 +163,14 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public SecpPubKey ecPubKeyTweakMul(SecpPoint.Uncompressed pubKey, BigInteger scalarMultiplier) {
+    public SecpPubKeyBc ecPubKeyTweakMul(SecpPoint.Uncompressed pubKey, BigInteger scalarMultiplier) {
         SecP256K1Point pubKeyBC = fromSecpPoint(pubKey);
         ECPoint pub = new FixedPointCombMultiplier().multiply(pubKeyBC, scalarMultiplier);
         return toSecpPubKey(pub);
     }
 
     @Override
-    public SecpPubKey ecPubKeyCombine(SecpPoint.Uncompressed  key1, SecpPoint.Uncompressed  key2) {
+    public SecpPubKeyBc ecPubKeyCombine(SecpPoint.Uncompressed  key1, SecpPoint.Uncompressed  key2) {
         SecP256K1Point pubKey1BC = fromSecpPoint(key1);
         SecP256K1Point pubKey2BC = fromSecpPoint(key2);
         ECPoint result = pubKey1BC.add(pubKey2BC);

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpKeyPairBc.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpKeyPairBc.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023-2026 secp256k1-jdk Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.secp.bouncy;
+
+import org.bitcoinj.secp.SecpKeyPair;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
+import org.bouncycastle.math.ec.custom.sec.SecP256K1Point;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.math.BigInteger;
+
+/**
+ * Bouncy Castle implementation of SecpKeyPair using {@link BigInteger} and {@link SecP256K1Point}.
+ */
+public class SecpKeyPairBc implements SecpKeyPair {
+    private @Nullable BigInteger privKey;
+    private final SecP256K1Point bcPoint;
+
+    SecpKeyPairBc(SecP256K1Point bcPoint, BigInteger privKey) {
+        this.privKey = privKey;
+        this.bcPoint = bcPoint;
+    }
+
+    @Override
+    public SecpPubKeyBc publicKey() {
+        return new SecpPubKeyBc(bcPoint);
+    }
+
+    @Override
+    public SecpPrivKeyBc privateKey() {
+        if (privKey == null) throwKeyDestroyed();
+        return new SecpPrivKeyBc(privKey);
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        if (privKey == null) throwKeyDestroyed();
+        return SecpScalarImpl.integerTo32Bytes(privKey);
+    }
+
+    @Override
+    public BigInteger getS() {
+        if (privKey == null) throwKeyDestroyed();
+        return privKey;
+    }
+
+    // Method to get pubkey as SecP256K1Point directly
+    SecP256K1Point getQ() {
+        return bcPoint;
+    }
+
+    @Override
+    public void destroy() {
+        privKey = null;
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return privKey == null;
+    }
+
+    private void throwKeyDestroyed() {
+        throw new IllegalStateException("Private Key has been destroyed");
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        throw new NotSerializableException("Serialization of private keys is prohibited.");
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        throw new NotSerializableException("Deserialization of private keys is prohibited.");
+    }
+}

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpPubKeyBc.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/SecpPubKeyBc.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 /**
  * Bouncy Castle implementation of SecpPubKey using {@link SecP256K1Point}.
  */
-class SecpPubKeyBc implements SecpPubKey {
+public class SecpPubKeyBc implements SecpPubKey {
     private final SecP256K1Point bcPoint;
 
     SecpPubKeyBc(SecP256K1Point bcPoint) {


### PR DESCRIPTION
Two commits:

* The first narrows the return type of some methods in `Bouncy256k1`
* The second implements `SecKeyPairBc ` to flatten memory and avoid unnecessary conversions.