### PR TITLE
Secp256k1: API: require SecpKeyPair for Schnorr Signing

### DIFF
--- a/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
+++ b/secp-api/src/main/java/org/bitcoinj/secp/Secp256k1.java
@@ -313,20 +313,20 @@ public interface Secp256k1 extends Closeable {
 
     /**
      * Create a Schnorr signature for a message.
-     * @param msg_hash a hash of a message to sign
-     * @param privKey private key for signing
+     * @param messageHash a hash of a message to sign
+     * @param keyPair key pair for signing
      * @return the signature
      */
-    SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpPrivKey privKey);
+    SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpKeyPair keyPair);
 
     /**
      * Create a Schnorr signature for a message.
      * @param messageHash a hash of a message to sign
-     * @param privKey private key for signing
+     * @param keyPair key pair for signing
      * @param auxiliaryRandom auxiliary randomness (typically from a test vector)
      * @return the signature
      */
-    SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpPrivKey privKey, byte[] auxiliaryRandom);
+    SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpKeyPair keyPair, byte[] auxiliaryRandom);
 
     /**
      * Verify a Schnorr signature.

--- a/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
+++ b/secp-bouncy/src/main/java/org/bitcoinj/secp/bouncy/Bouncy256k1.java
@@ -323,20 +323,21 @@ public class Bouncy256k1 implements Secp256k1 {
     }
 
     @Override
-    public SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpPrivKey privKey) {
+    public SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpKeyPair keyPair) {
         checkArg(msg_hash.length == 32, "Message must be 32-byte (hash)");
         byte[] auxiliaryRandom = new byte[32];
         try {
             fillRandom(auxiliaryRandom);
-            return schnorrSigSign32(msg_hash, privKey, auxiliaryRandom);
+            return schnorrSigSign32(msg_hash, keyPair, auxiliaryRandom);
         } finally {
             Arrays.fill(auxiliaryRandom, (byte) 0);
         }
     }
 
     @Override
-    public SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpPrivKey privKey, byte[] auxiliaryRandom) {
-        ECPrivateKeyParameters priv = new ECPrivateKeyParameters(privKey.getS(), BC_ECDOMAIN_PARAMS);
+    public SchnorrSignature schnorrSigSign32(byte[] msg_hash, SecpKeyPair keyPair, byte[] auxiliaryRandom) {
+        // TODO: Is there a way to pass the x-only pubkey to Bouncy Castle to save a point multiply?
+        ECPrivateKeyParameters priv = new ECPrivateKeyParameters(keyPair.getS(), BC_ECDOMAIN_PARAMS);
 
         BIP340Signer signer = new BIP340Signer();
 

--- a/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
+++ b/secp-ffm/src/main/java/org/bitcoinj/secp/ffm/Secp256k1Foreign.java
@@ -484,38 +484,36 @@ public class Secp256k1Foreign implements AutoCloseable, Secp256k1 {
     }
 
     @Override
-    public SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpPrivKey privKey) {
+    public SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpKeyPair keyPair) {
         checkArg(messageHash.length == 32, "Message must be 32-byte (hash)");
         try (Arena ta = Arena.ofConfined()) {
             MemorySegment auxiliary_rand = fill_random(ta, 32);
-            return schnorrSigSign32(ta, messageHash, privKey, auxiliary_rand);
+            return schnorrSigSign32(ta, messageHash, keyPair, auxiliary_rand);
         }
     }
 
-    /// schnorrSigSign32 using provided randomness. This is not part of the API and is intended for testing.
-    /// @param messageHash message hash
-    /// @param privKey private key
-    /// @param auxiliaryRandom auxiliary randomness (typically from a test vector)
-    /// @return the signature
-    public SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpPrivKey privKey, byte[] auxiliaryRandom) {
+    @Override
+    public SchnorrSignature schnorrSigSign32(byte[] messageHash, SecpKeyPair keyPair, byte[] auxiliaryRandom) {
         checkArg(messageHash.length == 32, "Message must be 32-byte (hash)");
         checkArg(auxiliaryRandom.length == 32, "auxiliaryRandom must be 32-byte)");
         try (Arena ta = Arena.ofConfined()) {
             MemorySegment auxiliary_rand = ta.allocateFrom(JAVA_BYTE, auxiliaryRandom);
-            return schnorrSigSign32(ta, messageHash, privKey, auxiliary_rand);
+            return schnorrSigSign32(ta, messageHash, keyPair, auxiliary_rand);
         }
     }
 
-    private SchnorrSignature schnorrSigSign32(SegmentAllocator alloc, byte[] messageHash, SecpPrivKey privKey, MemorySegment auxiliary_rand) {
+    private SchnorrSignature schnorrSigSign32(SegmentAllocator alloc, byte[] messageHash, SecpKeyPair keyPair, MemorySegment auxiliaryRand) {
+        MemorySegment hashSeg = alloc.allocateFrom(JAVA_BYTE, messageHash);
+        MemorySegment keyPairSeg = privKeyToSegment(alloc, keyPair.privateKey());
+        return schnorrSigSign32(alloc, hashSeg, keyPairSeg, auxiliaryRand);
+    }
+
+    private SchnorrSignature schnorrSigSign32(SegmentAllocator alloc, MemorySegment hashSeg, MemorySegment keyPairSeg, MemorySegment auxiliaryRand) {
         MemorySegment sig = alloc.allocate(64);
-        MemorySegment msg_hash = alloc.allocateFrom(JAVA_BYTE, messageHash);
-        MemorySegment keyPairSeg = privKeyToSegment(alloc, privKey);
-        int return_val = secp256k1_schnorrsig_sign32(ctx, sig, msg_hash, keyPairSeg, auxiliary_rand);
-        keyPairSeg.fill((byte) 0x00);   // Contains the private key
+        int return_val = secp256k1_schnorrsig_sign32(ctx, sig, hashSeg, keyPairSeg, auxiliaryRand);
         assert(return_val == 1);
         return SchnorrSignatureImpl.of(sig.toArray(JAVA_BYTE));
     }
-
 
     /// Get a segment with a private key in it. If `privKey` is an [SecpPrivKeyNative] we return
     /// the read-only segment provided by [SecpPrivKeyNative#segment()], otherwise we allocate

--- a/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/BIP340TestVectorTests.java
+++ b/secp-integration-test/src/test/java/org/bitcoinj/secp/integration/BIP340TestVectorTests.java
@@ -76,9 +76,9 @@ public class BIP340TestVectorTests implements SecpTestSupport {
     @ParameterizedTest
     @FieldSource("SIGN32_VECTORS")
     void schnorrSigSign32(TestVector vec) {
-        var privKey = secp.ecPrivKeyImport(vec.privKey);
+        var keyPair = secp.ecKeyPairCreate(secp.ecPrivKeyImport(vec.privKey));
 
-        var actualSignature = secp.schnorrSigSign32(vec.message, privKey, vec.auxRand);
+        var actualSignature = secp.schnorrSigSign32(vec.message, keyPair, vec.auxRand);
 
         assertArrayEquals(vec.signature, actualSignature.serialize());
     }


### PR DESCRIPTION
We were converting a privKey to keyPair internally (requiring point multiplication) because the libsecp256k1 C API requires keyPairs. Apparently, Bouncy Castle is doing similar point multiplication internally, but until their API changes we can't avoid that.